### PR TITLE
8 7 supplemental specs added

### DIFF
--- a/java/cli/src/main/java/org/brapi/schematools/cli/GenerateSubCommand.java
+++ b/java/cli/src/main/java/org/brapi/schematools/cli/GenerateSubCommand.java
@@ -215,7 +215,7 @@ public class GenerateSubCommand implements Runnable {
 
             for (OpenAPI specification : specifications) {
                 outputOpenAPISpecification(specification,
-                    outputPath != null ? outputPath.resolve(String.format("%s.json", specification.getInfo().getTitle())) : null);
+                    outputPath != null ? outputPath.resolve(String.format("%s.yaml", specification.getInfo().getTitle())) : null);
             }
         } catch (IOException e) {
             err.println(e.getMessage());

--- a/java/cli/src/main/java/org/brapi/schematools/cli/GenerateSubCommand.java
+++ b/java/cli/src/main/java/org/brapi/schematools/cli/GenerateSubCommand.java
@@ -29,6 +29,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
+import static org.brapi.schematools.cli.OutputFormat.GRAPHQL;
+import static org.brapi.schematools.cli.OutputFormat.GRAPHQL_INTROSPECTION;
+import static org.brapi.schematools.core.utils.OpenAPIUtils.OUTPUT_FORMAT_JSON;
+import static org.brapi.schematools.core.utils.OpenAPIUtils.OUTPUT_FORMAT_YAML;
 import static org.brapi.schematools.core.utils.OpenAPIUtils.prettyPrint;
 
 /**
@@ -65,7 +69,7 @@ public class GenerateSubCommand implements Runnable {
     @CommandLine.Option(names = {"-r", "--overwrite"}, description = "Overwrite the output file(s) if it already exists. True by default, if set to False the output wll not be over writen.")
     private boolean overwrite = true;
 
-    @CommandLine.Option(names = {"-x", "--throwExceptionOnFail"}, description = "Throw an exception on failure. False by default, if set to True if an exception is thrown when validation or generation fails.")
+    @CommandLine.Option(names = {"-x", "--throwExceptionOnFail"}, description = "Throw an exception on failure. False by default, if set to True to throw an exception when validation or generation fails.")
     private boolean throwExceptionOnFail = false;
 
     @CommandLine.Option(names = {"-t", "--stackTrace"}, description = "If an error is recorded output the stack trace.")
@@ -78,14 +82,14 @@ public class GenerateSubCommand implements Runnable {
 
             switch (outputFormat) {
 
-                case OPEN_API -> {
+                case OPEN_API, OPEN_API_JSON -> {
                     OpenAPIGeneratorOptions options = optionsPath != null ?
                         OpenAPIGeneratorOptions.load(optionsPath) : OpenAPIGeneratorOptions.load() ;
                     OpenAPIGeneratorMetadata metadata = metadataPath != null ?
                         OpenAPIGeneratorMetadata.load(metadataPath) :  OpenAPIGeneratorMetadata.load() ;
                     generateOpenAPISpecification(options, metadata);
                 }
-                case GRAPHQL -> {
+                case GRAPHQL, GRAPHQL_INTROSPECTION -> {
                     GraphQLGeneratorOptions options = optionsPath != null ?
                         GraphQLGeneratorOptions.load(optionsPath) : GraphQLGeneratorOptions.load();
                     GraphQLGeneratorMetadata metadata = metadataPath != null ?
@@ -107,17 +111,7 @@ public class GenerateSubCommand implements Runnable {
                 }
             }
         } catch (Exception exception) {
-
-            String message = String.format("%s: %s", exception.getClass().getSimpleName(), exception.getMessage()) ;
-            err.println(message);
-
-            if (stackTrace) {
-                exception.printStackTrace(err);
-            }
-
-            if (throwExceptionOnFail) {
-                throw new BrAPICommandException(message, exception) ;
-            }
+            handleFail(exception);
         } finally {
             if (out != null) {
                 out.close();
@@ -131,7 +125,10 @@ public class GenerateSubCommand implements Runnable {
 
         Response<GraphQLSchema> response = graphQLGenerator.generate(schemaDirectory, metadata);
 
-        response.onSuccessDoWithResult(this::outputIDLSchema).onFailDoWithResponse(this::printGraphQLSchemaErrors);
+        response
+            .onSuccessDoWithResultOnCondition(outputFormat == GRAPHQL, this::outputIDLSchema)
+            .onSuccessDoWithResultOnCondition(outputFormat == GRAPHQL_INTROSPECTION, this::outputIntrospectionSchema)
+            .onFailDoWithResponse(this::printGraphQLSchemaErrors);
     }
 
     private void outputIDLSchema(GraphQLSchema schema) {
@@ -140,8 +137,8 @@ public class GenerateSubCommand implements Runnable {
                 out.print(new SchemaPrinter().print(schema));
                 out.close();
             }
-        } catch (IOException e) {
-            err.println(e.getMessage());
+        } catch (IOException exception) {
+            handleFail(exception) ;
         }
     }
 
@@ -156,8 +153,8 @@ public class GenerateSubCommand implements Runnable {
                 out.print(mapper.writeValueAsString(executionResult.toSpecification().get("data")));
                 out.close();
             }
-        } catch (IOException e) {
-            err.println(e.getMessage());
+        } catch (IOException exception) {
+            handleFail(exception) ;
         }
     }
 
@@ -182,49 +179,45 @@ public class GenerateSubCommand implements Runnable {
         Response<List<OpenAPI>> response = openAPIGenerator.generate(schemaDirectory, componentsDirectory, metadata);
 
         response
-            .onSuccessDoWithResultOnCondition(!options.isSeparatingByModule(), this::outputOpenAPISpecificationFile)
-            .onSuccessDoWithResultOnCondition(options.isSeparatingByModule(), this::outputOpenAPISpecificationDirectory)
+            .onSuccessDoWithResult(this::outputOpenAPISpecifications)
             .onFailDoWithResponse(this::printOpenAPISpecificationErrors);
     }
 
-    private void outputOpenAPISpecificationFile(List<OpenAPI> specifications) {
+    private void outputOpenAPISpecifications(List<OpenAPI> specifications) {
         try {
             if (specifications.size() == 1) {
-                outputOpenAPISpecification(specifications.getFirst(), outputPath);
+                if (outputPath != null && Files.isDirectory(outputPath)) {
+                    outputOpenAPISpecification(specifications.getFirst(), resolveOutputPath(specifications.getFirst()));
+                } else {
+                    outputOpenAPISpecification(specifications.getFirst(), outputPath);
+                }
+
             } else {
                 if (specifications.isEmpty()) {
-                    err.println("No specification to to output!");
+                    handleFail("No specification to to output!");
                 } else {
-                    err.printf("Can not output several specification to single file: '%s' :%n", outputPath.toFile());
+                    if (outputPath != null && Files.isRegularFile(outputPath)) {
+                        handleFail(String.format("Output path '%s' must be a directory if outputting to separate files.", outputPath.toFile()));
+                    } else {
+                        for (OpenAPI specification : specifications) {
+                            outputOpenAPISpecification(specification, resolveOutputPath(specification));
+                        }
+                    }
                 }
             }
-        } catch (IOException e) {
-            err.println(e.getMessage());
+        } catch (IOException exception) {
+            handleFail(exception) ;
         }
     }
 
-    private void outputOpenAPISpecificationDirectory(List<OpenAPI> specifications) {
-        try {
-            if (outputPath != null) {
-                if (Files.isRegularFile(outputPath)) {
-                    err.printf("Output path '%s' must be a directory if outputting separate files:%n", outputPath.toFile());
-                }
-
-                Files.createDirectories(outputPath);
-            }
-
-            for (OpenAPI specification : specifications) {
-                outputOpenAPISpecification(specification,
-                    outputPath != null ? outputPath.resolve(String.format("%s.yaml", specification.getInfo().getTitle())) : null);
-            }
-        } catch (IOException e) {
-            err.println(e.getMessage());
-        }
+    private Path resolveOutputPath(OpenAPI specification) {
+        return outputPath != null ? outputPath.resolve(
+            String.format(outputFormat == OutputFormat.OPEN_API ? "%s.yaml" : "%s.json", specification.getInfo().getTitle())) : null ;
     }
 
     private void outputOpenAPISpecification(OpenAPI specification, Path outputPath) throws IOException {
         if (openWriter(outputPath)) {
-            out.print(prettyPrint(specification));
+            out.print(prettyPrint(specification, outputFormat == OutputFormat.OPEN_API_JSON ? OUTPUT_FORMAT_JSON : OUTPUT_FORMAT_YAML));
             out.close();
         }
     }
@@ -259,8 +252,8 @@ public class GenerateSubCommand implements Runnable {
                 out.flush();
                 out.close();
             }
-        } catch (IOException e) {
-            err.println(e.getMessage());
+        } catch (IOException exception) {
+            handleFail(exception) ;
         }
     }
 
@@ -281,10 +274,16 @@ public class GenerateSubCommand implements Runnable {
 
     private boolean openWriter(Path outputPathFile) throws IOException {
         if (outputPathFile != null) {
+
+            if (Files.isDirectory(outputPathFile)) {
+                handleFail(String.format("Output path '%s' is a directory", outputPath));
+                return false ;
+            }
+
             Files.createDirectories(outputPathFile.getParent());
 
-            if (!overwrite && Files.exists(outputPathFile)) {
-                err.println(String.format("Output file '%s' already exists was not overwritten", outputPath));
+            if (!overwrite && Files.isRegularFile(outputPathFile)) {
+                handleFail(String.format("Output file '%s' already exists was not overwritten", outputPath));
                 return false ;
             }
 
@@ -300,21 +299,22 @@ public class GenerateSubCommand implements Runnable {
         try {
             if (outputPath != null) {
                 if (Files.isRegularFile(outputPath)) {
-                    err.println("For Markdown generation the output path must be a directory");
+                    handleFail("For Markdown generation the output path must be a directory");
+                } else {
+
+                    Files.createDirectories(outputPath);
+
+                    MarkdownGenerator markdownGenerator = new MarkdownGenerator(outputPath, overwrite);
+
+                    Response<List<Path>> response = markdownGenerator.generate(schemaDirectory);
+
+                    response.onSuccessDoWithResult(this::outputMarkdownPaths).onFailDoWithResponse(this::printMarkdownErrors);
                 }
-
-                Files.createDirectories(outputPath);
-
-                MarkdownGenerator markdownGenerator = new MarkdownGenerator(outputPath, overwrite);
-
-                Response<List<Path>> response = markdownGenerator.generate(schemaDirectory);
-
-                response.onSuccessDoWithResult(this::outputMarkdownPaths).onFailDoWithResponse(this::printMarkdownErrors);
             } else {
-                err.println("For Markdown generation the output directory must be provided");
+                handleFail("For Markdown generation the output directory must be provided");
             }
         } catch (IOException exception) {
-            err.println(exception.getMessage());
+            handleFail(exception) ;
         }
     }
 
@@ -323,7 +323,7 @@ public class GenerateSubCommand implements Runnable {
             System.out.println("Did not generate any markdown files");
         } else if (paths.size() == 1) {
             System.out.println("Generated '1' markdown file:");
-            System.out.println(paths.get(0).toString());
+            System.out.println(paths.getFirst().toString());
         } else {
             System.out.printf("Generated '%s' markdown files:%n", paths.size());
             paths.forEach(path -> System.out.println(path.toString()));
@@ -353,19 +353,20 @@ public class GenerateSubCommand implements Runnable {
                 // TODO option for split files by module
 
                 if (Files.exists(outputPath) && !Files.isRegularFile(outputPath)) {
-                    err.println("For Excel (xlsx) generation the output path must be a file");
+                    handleFail("For Excel (xlsx) generation the output path must be a file");
+                } else {
+
+                    XSSFWorkbookGenerator xssfWorkbookGenerator = new XSSFWorkbookGenerator(outputPath);
+
+                    Response<List<Path>> response = xssfWorkbookGenerator.generate(schemaDirectory);
+
+                    response.onSuccessDoWithResult(this::outputExcelPaths).onFailDoWithResponse(this::printExcelErrors);
                 }
-
-                XSSFWorkbookGenerator xssfWorkbookGenerator = new XSSFWorkbookGenerator(outputPath);
-
-                Response<List<Path>> response = xssfWorkbookGenerator.generate(schemaDirectory);
-
-                response.onSuccessDoWithResult(this::outputExcelPaths).onFailDoWithResponse(this::printExcelErrors);
             } else {
-                err.println("For Excel (xlsx) generation the output file must be provided");
+                handleFail("For Excel (xlsx) generation the output file must be provided");
             }
         } catch (Exception exception) {
-            err.println(exception.getMessage());
+            handleFail(exception);
         }
     }
 
@@ -373,10 +374,10 @@ public class GenerateSubCommand implements Runnable {
         if (paths.isEmpty()) {
             System.out.println("Did not generate any excel files");
         } else if (paths.size() == 1) {
-            System.out.println(String.format("Generated '1' excel file:"));
-            System.out.println(paths.get(0).toString());
+            System.out.println("Generated '1' excel file:");
+            System.out.println(paths.getFirst().toString());
         } else {
-            System.out.println(String.format("Generated '%s' excel files:", paths.size()));
+            System.out.printf("Generated '%s' excel files:%n", paths.size());
             paths.forEach(path -> System.out.println(path.toString()));
         }
     }
@@ -393,6 +394,27 @@ public class GenerateSubCommand implements Runnable {
 
         if (throwExceptionOnFail) {
             throw new BrAPICommandException(message, response.getAllErrors()) ;
+        }
+    }
+
+    private void handleFail(Exception exception) {
+        String message = String.format("%s: %s", exception.getClass().getSimpleName(), exception.getMessage()) ;
+        err.println(message);
+
+        if (stackTrace) {
+            exception.printStackTrace(err);
+        }
+
+        if (throwExceptionOnFail) {
+            throw new BrAPICommandException(message, exception) ;
+        }
+    }
+
+    private void handleFail(String message) {
+        err.println(message);
+
+        if (throwExceptionOnFail) {
+            throw new BrAPICommandException(message) ;
         }
     }
 

--- a/java/cli/src/main/java/org/brapi/schematools/cli/LoginSubCommand.java
+++ b/java/cli/src/main/java/org/brapi/schematools/cli/LoginSubCommand.java
@@ -1,7 +1,6 @@
 package org.brapi.schematools.cli;
 
 import org.brapi.schematools.analyse.authorization.oauth.SingleSignOn;
-import org.brapi.schematools.core.response.Response;
 import picocli.CommandLine;
 
 import java.io.PrintStream;

--- a/java/cli/src/main/java/org/brapi/schematools/cli/OutputFormat.java
+++ b/java/cli/src/main/java/org/brapi/schematools/cli/OutputFormat.java
@@ -6,13 +6,21 @@ package org.brapi.schematools.cli;
 public enum OutputFormat {
 
     /**
-     * Use this format to generate an OpenAPI specification
+     * Use this format to generate an OpenAPI specification in YAML
      */
     OPEN_API,
+    /**
+     * Use this format to generate an OpenAPI specification in JSON
+     */
+    OPEN_API_JSON,
     /**
      * Use this format to generate a GraphQL schema
      */
     GRAPHQL,
+    /**
+     * Use this format to generate a GraphQL schema in introspection format
+     */
+    GRAPHQL_INTROSPECTION,
     /**
      * Use this format to generate OWL specification in turtle format
      */
@@ -21,6 +29,7 @@ public enum OutputFormat {
      * Use this format to generate Markdown for type and their field descriptions
      */
     MARKDOWN,
+
     /**
      * Use this format to generate Excel (xlsx) for types and their field descriptions
      */

--- a/java/core/src/main/java/org/brapi/schematools/core/openapi/comparator/OpenAPIComparator.java
+++ b/java/core/src/main/java/org/brapi/schematools/core/openapi/comparator/OpenAPIComparator.java
@@ -42,7 +42,8 @@ public class OpenAPIComparator {
      */
     public Response<ChangedOpenApi> compare(Path firstPath, Path secondPath) {
         if (Files.isRegularFile(firstPath) && Files.isRegularFile(secondPath)) {
-            return Response.success(OpenApiCompare.fromFiles(firstPath.toFile(), secondPath.toFile())) ;
+            ChangedOpenApi diff = OpenApiCompare.fromFiles(firstPath.toFile(), secondPath.toFile());
+            return Response.success(diff);
         } else {
             if (!Files.isRegularFile(firstPath) && !Files.isRegularFile(secondPath)) {
                 return Response.fail(Response.ErrorType.VALIDATION,

--- a/java/core/src/main/java/org/brapi/schematools/core/openapi/generator/OpenAPIGenerator.java
+++ b/java/core/src/main/java/org/brapi/schematools/core/openapi/generator/OpenAPIGenerator.java
@@ -20,6 +20,7 @@ import org.brapi.schematools.core.openapi.generator.options.OpenAPIGeneratorOpti
 import org.brapi.schematools.core.response.Response;
 import org.brapi.schematools.core.utils.BrAPITypeUtils;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.file.Path;
 import java.util.*;
@@ -223,8 +224,13 @@ public class OpenAPIGenerator {
 
             OpenAPI openAPI;
             if(supplementalSpecPath != null && !supplementalSpecPath.isEmpty()) {
-                OpenAPI supplementalOpenAPI = new OpenAPIParser().readLocation(supplementalSpecPath, null, null).getOpenAPI();
-                openAPI = Objects.requireNonNullElseGet(supplementalOpenAPI, OpenAPI::new);
+                try {
+                    String supplementalSpecPathAbs = Path.of(supplementalSpecPath).toRealPath().toString();
+                    OpenAPI supplementalOpenAPI = new OpenAPIParser().readLocation(supplementalSpecPathAbs, null, null).getOpenAPI();
+                    openAPI = Objects.requireNonNullElseGet(supplementalOpenAPI, OpenAPI::new);
+                } catch (IOException e) {
+                    return Response.fail(Response.ErrorType.VALIDATION, String.format("Can not find supplemental specification file : %s", e.getMessage()));
+                }
             }else{
                 openAPI = new OpenAPI();
             }

--- a/java/core/src/main/java/org/brapi/schematools/core/openapi/generator/metadata/OpenAPIGeneratorMetadata.java
+++ b/java/core/src/main/java/org/brapi/schematools/core/openapi/generator/metadata/OpenAPIGeneratorMetadata.java
@@ -6,8 +6,6 @@ import lombok.Getter;
 import lombok.Setter;
 import lombok.experimental.Accessors;
 import org.brapi.schematools.core.metadata.Metadata;
-import org.brapi.schematools.core.model.BrAPIType;
-import org.brapi.schematools.core.openapi.generator.options.ListGetOptions;
 import org.brapi.schematools.core.utils.ConfigurationUtils;
 
 import java.io.IOException;

--- a/java/core/src/main/java/org/brapi/schematools/core/openapi/generator/options/OpenAPIGeneratorOptions.java
+++ b/java/core/src/main/java/org/brapi/schematools/core/openapi/generator/options/OpenAPIGeneratorOptions.java
@@ -48,6 +48,11 @@ public class OpenAPIGeneratorOptions extends AbstractGeneratorOptions {
     @Setter(AccessLevel.PRIVATE)
     private PropertiesOptions properties;
 
+    @Getter(AccessLevel.PUBLIC)
+    private String supplementalSpecification;
+    @Getter(AccessLevel.NONE)
+    @Setter(AccessLevel.PRIVATE)
+    private Map<String, String> supplementalSpecificationFor = new HashMap<>();
     @Getter(AccessLevel.PRIVATE)
     private Boolean separateByModule;
     @Getter(AccessLevel.PRIVATE)
@@ -147,6 +152,14 @@ public class OpenAPIGeneratorOptions extends AbstractGeneratorOptions {
             generateNewRequest = overrideOptions.generateNewRequest ;
         }
 
+        if (overrideOptions.supplementalSpecification != null) {
+            supplementalSpecification = overrideOptions.supplementalSpecification ;
+        }
+
+        if (overrideOptions.supplementalSpecificationFor != null) {
+            supplementalSpecificationFor.putAll(overrideOptions.supplementalSpecificationFor) ;
+        }
+
         if (overrideOptions.generateNewRequestFor != null) {
             generateNewRequestFor.putAll(overrideOptions.generateNewRequestFor) ;
         }
@@ -196,6 +209,8 @@ public class OpenAPIGeneratorOptions extends AbstractGeneratorOptions {
             .merge(delete)
             .merge(search)
             .merge(properties)
+            .assertNotNull(supplementalSpecification, "'supplementalSpecification' option is null")
+            .assertNotNull(supplementalSpecificationFor, "'supplementalSpecificationFor' option is null")
             .assertNotNull(generateNewRequestFor, "'generateNewRequestFor' option is null")
             .assertNotNull(newRequestNameFormat,  "'newRequestNameFormat' option is null")
             .assertNotNull(singleResponseNameFormat, "'singleResponseNameFormat' option is null")
@@ -279,6 +294,12 @@ public class OpenAPIGeneratorOptions extends AbstractGeneratorOptions {
     @JsonIgnore
     public final boolean isGeneratingEndpointNameWithIdFor(@NonNull BrAPIType type) {
         return isGeneratingEndpointNameWithIdFor(type.getName()) ;
+    }
+
+
+    @JsonIgnore
+    public String getSupplementalSpecificationFor(@NonNull String name) {
+        return supplementalSpecificationFor.getOrDefault(name, supplementalSpecification) ;
     }
 
     /**

--- a/java/core/src/main/java/org/brapi/schematools/core/utils/OpenAPIUtils.java
+++ b/java/core/src/main/java/org/brapi/schematools/core/utils/OpenAPIUtils.java
@@ -6,9 +6,16 @@ import com.fasterxml.jackson.core.util.DefaultPrettyPrinter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.swagger.v3.core.util.Json;
 import io.swagger.v3.core.util.Json31;
+import io.swagger.v3.core.util.Yaml;
+import io.swagger.v3.core.util.Yaml31;
 import io.swagger.v3.oas.models.OpenAPI;
 
+import java.util.Objects;
+
 public class OpenAPIUtils {
+
+    public final static String OUTPUT_FORMAT_YAML = "YAML";
+    public final static String OUTPUT_FORMAT_JSON = "JSON";
     /**
      * Pretty print an OpenAPI object to a JSON String, with a default indentation of 4 spaces.
      * @param openAPI the object to be Pretty printed
@@ -16,7 +23,16 @@ public class OpenAPIUtils {
      * @throws JsonProcessingException if the object cannot be converted to JSON.
      */
     public static String prettyPrint(OpenAPI openAPI) throws JsonProcessingException {
-        return prettyPrint(openAPI, 4) ;
+        return prettyPrint(openAPI, 4, OUTPUT_FORMAT_YAML) ;
+    }
+    /**
+     * Pretty print an OpenAPI object to a JSON String, with a default indentation of 4 spaces.
+     * @param openAPI the object to be Pretty printed
+     * @return Pretty print JSON String version of the object
+     * @throws JsonProcessingException if the object cannot be converted to JSON.
+     */
+    public static String prettyPrint(OpenAPI openAPI, String format) throws JsonProcessingException {
+        return prettyPrint(openAPI, 4, format) ;
     }
 
     /**
@@ -26,11 +42,20 @@ public class OpenAPIUtils {
      * @return Pretty print JSON String version of the object
      * @throws JsonProcessingException if the object cannot be converted to JSON.
      */
-    public static String prettyPrint(OpenAPI openAPI, int indent) throws JsonProcessingException {
-        ObjectMapper mapper = switch (openAPI.getSpecVersion()) {
-            case V30 -> Json.mapper() ;
-            case V31 -> Json31.mapper() ;
-        } ;
+    public static String prettyPrint(OpenAPI openAPI, int indent, String format) throws JsonProcessingException {
+        ObjectMapper mapper;
+
+        if (OUTPUT_FORMAT_JSON.equals(format)){
+            mapper = switch (openAPI.getSpecVersion()) {
+                case V30 -> Json.mapper();
+                case V31 -> Json31.mapper();
+            };
+        } else {
+            mapper = switch (openAPI.getSpecVersion()) {
+                case V30 -> Yaml.mapper();
+                case V31 -> Yaml31.mapper();
+            };
+        }
 
         DefaultPrettyPrinter.Indenter indenter =
             new DefaultIndenter(" ".repeat(indent), DefaultIndenter.SYS_LF);

--- a/java/core/src/main/java/org/brapi/schematools/core/utils/OpenAPIUtils.java
+++ b/java/core/src/main/java/org/brapi/schematools/core/utils/OpenAPIUtils.java
@@ -10,8 +10,6 @@ import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.core.util.Yaml31;
 import io.swagger.v3.oas.models.OpenAPI;
 
-import java.util.Objects;
-
 public class OpenAPIUtils {
 
     public final static String OUTPUT_FORMAT_YAML = "YAML";

--- a/java/core/src/main/java/org/brapi/schematools/core/xlsx/XSSFWorkbookGenerator.java
+++ b/java/core/src/main/java/org/brapi/schematools/core/xlsx/XSSFWorkbookGenerator.java
@@ -1,6 +1,5 @@
 package org.brapi.schematools.core.xlsx;
 
-import com.google.common.collect.Lists;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.beanutils.PropertyUtils;

--- a/java/core/src/main/resources/openapi-Supplemental-Spec-V2.1-BrAPI-Core.yaml
+++ b/java/core/src/main/resources/openapi-Supplemental-Spec-V2.1-BrAPI-Core.yaml
@@ -1,0 +1,175 @@
+info:
+  title: BrAPI
+  version: ''
+openapi: 3.0.0
+paths:
+  /serverinfo:
+    get:
+      description: |-
+        Implementation Notes
+        
+        Having a consistent structure for the path string of each call is very 
+        important for teams to be able to connect and find errors. Read more on Github.
+        
+        Here are the rules for the path of each call that should be returned
+        
+        Every word in the call path should match the documentation exactly, both in 
+        spelling and capitalization. Note that path strings are all lower case, but 
+        path parameters are camel case.
+        
+        Each path should start relative to \"/\" and therefore should not include \"/\"
+        
+        No leading or trailing slashes (\"/\") 
+        
+        Path parameters are wrapped in curly braces (\"{}\"). The name of the path parameter 
+        should be spelled exactly as it is specified in the documentation.
+        
+        Examples 
+        
+        GOOD   "call": "germplasm/{germplasmDbId}/pedigree" 
+        
+        BAD    "call": "germplasm/{id}/pedigree"
+        
+        BAD    "call": "germplasm/{germplasmDBid}/pedigree" 
+        
+        BAD    "call": "brapi/v2/germplasm/{germplasmDbId}/pedigree" 
+        
+        BAD    "call": "/germplasm/{germplasmDbId}/pedigree/" 
+        
+        BAD    "call": "germplasm/<germplasmDbId>/pedigree"
+      parameters:
+      - description: Filter the list of endpoints based on the response content type.
+        in: query
+        name: contentType
+        required: false
+        schema:
+          $ref: '#/components/schemas/ContentTypes'
+      - description: |-
+          **Deprecated in v2.1** Please use `contentType`. Github issue number #443
+          <br>The data format supported by the call.
+        deprecated: true
+        in: query
+        name: dataType
+        required: false
+        schema:
+          $ref: '#/components/schemas/ContentTypes'
+      - $ref: '#/components/parameters/authorizationHeader'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                properties:
+                  '@context':
+                    $ref: '#/components/schemas/Context'
+                  metadata:
+                    $ref: '#/components/schemas/metadata'
+                  result:
+                    $ref: '#/components/schemas/ServerInfo'
+                required:
+                - metadata
+                - result
+                title: ServerInfoResponse
+                type: object
+          description: OK
+          headers: {}
+        '400':
+          $ref: '#/components/responses/400BadRequest'
+        '401':
+          $ref: '#/components/responses/401Unauthorized'
+        '403':
+          $ref: '#/components/responses/403Forbidden'
+      summary: Get the list of implemented Calls
+      tags:
+      - Server Info
+components:
+  schemas:
+    Service: 
+      type: object
+      required:
+      - service
+      - versions
+      - methods
+      properties:
+        service:
+          description: The name of the available call as recorded in the documentation
+          type: string
+          example: germplasm/{germplasmDbId}/pedigree
+        contentTypes:
+          description: The possible content types returned by the service endpoint
+          items:
+            $ref: '#/components/schemas/ContentTypes'
+          type: array
+          example: ['application/json']
+        dataTypes:
+          description:  |-
+            **Deprecated in v2.1** Please use `contentTypes`. Github issue number #443 
+            <br/>The possible data formats returned by the available call 
+          deprecated: true
+          items:
+            $ref: '#/components/schemas/ContentTypes'
+          type: array
+          example: ['application/json']
+        methods:
+          description: The possible HTTP Methods to be used with the available call
+          items:
+            enum:
+            - GET
+            - POST
+            - PUT
+            - DELETE
+            type: string
+          type: array
+          example: ['GET', 'POST']
+        versions:
+          description: The supported versions of a particular call
+          items:
+            enum:
+            - '2.0'
+            - '2.1'
+            - '2.2'
+            type: string
+          type: array
+          example: ['2.0', '2.1']
+    ServerInfo: 
+      type: object
+      required:
+      - calls
+      properties:
+        contactEmail:
+          description: A contact email address for this server management
+          type: string
+          example: contact@institute.org
+        documentationURL:
+          description: A URL to the human readable documentation of an object
+          type: string
+          example: institute.org/server
+        organizationURL:
+          description: The URL of the organization that manages this server and data
+          type: string
+          example: institute.org/home
+        organizationName:
+          description: The name of the organization that manages this server and data
+          type: string
+          example: The Institute
+        serverName:
+          description: The name of this server
+          type: string
+          example: The BrAPI Test Server
+        serverDescription:
+          description: A description of this server
+          type: string
+          example: |-
+            The BrAPI Test Server
+            Web Server - Apache Tomcat 7.0.32
+            Database - Postgres 10
+            Supported BrAPI Version - V2.0
+        location:
+          description: Physical location of this server (ie. City, Country)
+          type: string
+          example: USA
+        calls:
+          description: Array of available calls on this server
+          items:
+            $ref: '#/components/schemas/Service'
+          type: array

--- a/java/core/src/main/resources/openapi-options.yaml
+++ b/java/core/src/main/resources/openapi-options.yaml
@@ -1,3 +1,6 @@
+supplementalSpecification: ''
+supplementalSpecificationFor:
+    BrAPI-Core: C:\Users\ps664\Documents\BrAPI\API\Specification\BrAPI-Core\BrAPI-Core-Supplemental-Spec.yaml
 separateByModule: true
 generateNewRequest: true
 generateNewRequestFor:

--- a/java/core/src/main/resources/openapi-options.yaml
+++ b/java/core/src/main/resources/openapi-options.yaml
@@ -1,6 +1,6 @@
 supplementalSpecification: ''
 supplementalSpecificationFor:
-    BrAPI-Core: C:\Users\ps664\Documents\BrAPI\API\Specification\BrAPI-Core\BrAPI-Core-Supplemental-Spec.yaml
+    BrAPI-Core: ''
 separateByModule: true
 generateNewRequest: true
 generateNewRequestFor:

--- a/java/core/src/test/java/org/brapi/schematools/core/openapi/generator/OpenAPIGeneratorTest.java
+++ b/java/core/src/test/java/org/brapi/schematools/core/openapi/generator/OpenAPIGeneratorTest.java
@@ -20,6 +20,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 
 import static org.brapi.schematools.core.test.TestUtils.assertJSONEquals;
+import static org.brapi.schematools.core.utils.OpenAPIUtils.OUTPUT_FORMAT_JSON;
 import static org.brapi.schematools.core.utils.StringUtils.isJSONEqual;
 import static org.brapi.schematools.core.utils.OpenAPIUtils.prettyPrint;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -214,7 +215,7 @@ class OpenAPIGeneratorTest {
     private void assertSpecificationEquals(String classPath, OpenAPI specification) {
         try {
             String expected = StringUtils.readStringFromPath(Path.of(ClassLoader.getSystemResource(classPath).toURI())).getResultOrThrow() ;
-            String actual = prettyPrint(specification);
+            String actual = prettyPrint(specification, OUTPUT_FORMAT_JSON);
 
             if (!isJSONEqual(expected, actual)) {
                 Path build = Paths.get("build", classPath);

--- a/java/core/src/test/java/org/brapi/schematools/core/openapi/generator/OpenAPIGeneratorTest.java
+++ b/java/core/src/test/java/org/brapi/schematools/core/openapi/generator/OpenAPIGeneratorTest.java
@@ -1,7 +1,5 @@
 package org.brapi.schematools.core.openapi.generator;
 
-import io.swagger.v3.core.util.Json;
-import io.swagger.v3.core.util.Json31;
 import io.swagger.v3.oas.models.OpenAPI;
 import lombok.extern.slf4j.Slf4j;
 import org.brapi.schematools.core.openapi.generator.metadata.OpenAPIGeneratorMetadata;
@@ -21,8 +19,8 @@ import java.util.stream.Collectors;
 
 import static org.brapi.schematools.core.test.TestUtils.assertJSONEquals;
 import static org.brapi.schematools.core.utils.OpenAPIUtils.OUTPUT_FORMAT_JSON;
-import static org.brapi.schematools.core.utils.StringUtils.isJSONEqual;
 import static org.brapi.schematools.core.utils.OpenAPIUtils.prettyPrint;
+import static org.brapi.schematools.core.utils.StringUtils.isJSONEqual;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;

--- a/java/core/src/test/java/org/brapi/schematools/core/utils/StringUtilsTest.java
+++ b/java/core/src/test/java/org/brapi/schematools/core/utils/StringUtilsTest.java
@@ -2,14 +2,10 @@ package org.brapi.schematools.core.utils;
 
 import org.junit.jupiter.api.Test;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.StringReader;
 import java.nio.file.Path;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 

--- a/java/core/src/test/resources/OpenAPIGenerator/BrAPI-Core.json
+++ b/java/core/src/test/resources/OpenAPIGenerator/BrAPI-Core.json
@@ -7,120 +7,101 @@
     "paths" : {
         "/lists" : {
             "get" : {
-                "tags" : [
-                    "Lists"
-                ],
+                "tags" : [ "Lists" ],
                 "summary" : "Get a filtered list of List",
                 "description" : "Get a list of List",
-                "parameters" : [
-                    {
-                        "name" : "dateCreatedRangeStart",
-                        "in" : "query",
-                        "description" : "Define the beginning for an interval of time and only include Lists that are created within this interval.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "dateCreatedRangeEnd",
-                        "in" : "query",
-                        "description" : "Define the end for an interval of time and only include Lists that are created within this interval.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "dateModifiedRangeStart",
-                        "in" : "query",
-                        "description" : "Define the beginning for an interval of time and only include Lists that are modified within this interval.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "dateModifiedRangeEnd",
-                        "in" : "query",
-                        "description" : "Define the end for an interval of time and only include Lists that are modified within this interval.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "listDbId",
-                        "in" : "query",
-                        "description" : "An array of primary database identifiers to identify a set of Lists",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "listName",
-                        "in" : "query",
-                        "description" : "An array of human readable names to identify a set of Lists",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "listOwnerName",
-                        "in" : "query",
-                        "description" : "An array of names for the people or entities who are responsible for a set of Lists",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "listOwnerPersonDbId",
-                        "in" : "query",
-                        "description" : "An array of primary database identifiers to identify people or entities who are responsible for a set of Lists",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "listSource",
-                        "in" : "query",
-                        "description" : "An array of terms identifying lists from different sources (ie 'USER', 'SYSTEM', etc)",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "listType",
-                        "in" : "query",
-                        "required" : false,
-                        "schema" : {
-                            "$ref" : "#/components/schemas/ListType"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "dateCreatedRangeStart",
+                    "in" : "query",
+                    "description" : "Define the beginning for an interval of time and only include Lists that are created within this interval.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "dateCreatedRangeEnd",
+                    "in" : "query",
+                    "description" : "Define the end for an interval of time and only include Lists that are created within this interval.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "dateModifiedRangeStart",
+                    "in" : "query",
+                    "description" : "Define the beginning for an interval of time and only include Lists that are modified within this interval.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "dateModifiedRangeEnd",
+                    "in" : "query",
+                    "description" : "Define the end for an interval of time and only include Lists that are modified within this interval.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "listDbId",
+                    "in" : "query",
+                    "description" : "An array of primary database identifiers to identify a set of Lists",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "listName",
+                    "in" : "query",
+                    "description" : "An array of human readable names to identify a set of Lists",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "listOwnerName",
+                    "in" : "query",
+                    "description" : "An array of names for the people or entities who are responsible for a set of Lists",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "listOwnerPersonDbId",
+                    "in" : "query",
+                    "description" : "An array of primary database identifiers to identify people or entities who are responsible for a set of Lists",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "listSource",
+                    "in" : "query",
+                    "description" : "An array of terms identifying lists from different sources (ie 'USER', 'SYSTEM', etc)",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "listType",
+                    "in" : "query",
+                    "required" : false,
+                    "schema" : {
+                        "$ref" : "#/components/schemas/ListType"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/ListListResponse"
@@ -137,16 +118,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "Lists"
-                ],
+                "tags" : [ "Lists" ],
                 "summary" : "Create new List",
                 "description" : "Add new List to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -174,174 +151,149 @@
         },
         "/locations" : {
             "get" : {
-                "tags" : [
-                    "Locations"
-                ],
+                "tags" : [ "Locations" ],
                 "summary" : "Get a filtered list of Location",
                 "description" : "Get a list of Location",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "locationDbId",
-                        "in" : "query",
-                        "description" : "The location ids to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "locationName",
-                        "in" : "query",
-                        "description" : "A human readable names to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "abbreviation",
-                        "in" : "query",
-                        "description" : "A list of shortened human readable names for a set of Locations",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "altitudeMin",
-                        "in" : "query",
-                        "description" : "The minimum altitude to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "number"
-                        }
-                    },
-                    {
-                        "name" : "altitudeMax",
-                        "in" : "query",
-                        "description" : "The maximum altitude to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "number"
-                        }
-                    },
-                    {
-                        "name" : "countryCode",
-                        "in" : "query",
-                        "description" : "[ISO_3166-1_alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) spec",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "countryName",
-                        "in" : "query",
-                        "description" : "The full name of the country to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "coordinate",
-                        "in" : "query",
-                        "required" : false,
-                        "schema" : {
-                            "$ref" : "#/components/schemas/GeoJSONSearchArea"
-                        }
-                    },
-                    {
-                        "name" : "instituteAddress",
-                        "in" : "query",
-                        "description" : "The street address of the institute to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "instituteName",
-                        "in" : "query",
-                        "description" : "The name of the institute to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "locationType",
-                        "in" : "query",
-                        "description" : "The type of location this represents (ex. Breeding Location, Storage Location, etc)",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "parentLocationDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier for a Location\n<br/> The Parent Location defines the encompassing location that this location belongs to. \nFor example, an Institution might have multiple Field Stations inside it and each Field Station might have multiple Fields.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "parentLocationName",
-                        "in" : "query",
-                        "description" : "A human readable name for a location\n<br/> The Parent Location defines the encompassing location that this location belongs to. \nFor example, an Institution might have multiple Field Stations inside it and each Field Station might have multiple Fields.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "locationDbId",
+                    "in" : "query",
+                    "description" : "The location ids to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "locationName",
+                    "in" : "query",
+                    "description" : "A human readable names to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "abbreviation",
+                    "in" : "query",
+                    "description" : "A list of shortened human readable names for a set of Locations",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "altitudeMin",
+                    "in" : "query",
+                    "description" : "The minimum altitude to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "number"
+                    }
+                }, {
+                    "name" : "altitudeMax",
+                    "in" : "query",
+                    "description" : "The maximum altitude to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "number"
+                    }
+                }, {
+                    "name" : "countryCode",
+                    "in" : "query",
+                    "description" : "[ISO_3166-1_alpha-3](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-3) spec",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "countryName",
+                    "in" : "query",
+                    "description" : "The full name of the country to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "coordinate",
+                    "in" : "query",
+                    "required" : false,
+                    "schema" : {
+                        "$ref" : "#/components/schemas/GeoJSONSearchArea"
+                    }
+                }, {
+                    "name" : "instituteAddress",
+                    "in" : "query",
+                    "description" : "The street address of the institute to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "instituteName",
+                    "in" : "query",
+                    "description" : "The name of the institute to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "locationType",
+                    "in" : "query",
+                    "description" : "The type of location this represents (ex. Breeding Location, Storage Location, etc)",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "parentLocationDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier for a Location\n<br/> The Parent Location defines the encompassing location that this location belongs to. \nFor example, an Institution might have multiple Field Stations inside it and each Field Station might have multiple Fields.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "parentLocationName",
+                    "in" : "query",
+                    "description" : "A human readable name for a location\n<br/> The Parent Location defines the encompassing location that this location belongs to. \nFor example, an Institution might have multiple Field Stations inside it and each Field Station might have multiple Fields.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/LocationListResponse"
@@ -358,16 +310,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "Locations"
-                ],
+                "tags" : [ "Locations" ],
                 "summary" : "Create new Location",
                 "description" : "Add new Location to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -395,130 +343,110 @@
         },
         "/people" : {
             "get" : {
-                "tags" : [
-                    "People"
-                ],
+                "tags" : [ "People" ],
                 "summary" : "Get a filtered list of Person",
                 "description" : "Get a list of Person",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "emailAddress",
-                        "in" : "query",
-                        "description" : "email address for this person",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "firstName",
-                        "in" : "query",
-                        "description" : "Persons first name",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "lastName",
-                        "in" : "query",
-                        "description" : "Persons last name",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "mailingAddress",
-                        "in" : "query",
-                        "description" : "physical address of this person",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "middleName",
-                        "in" : "query",
-                        "description" : "Persons middle name",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "personDbId",
-                        "in" : "query",
-                        "description" : "Unique ID for this person",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "phoneNumber",
-                        "in" : "query",
-                        "description" : "phone number of this person",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "userID",
-                        "in" : "query",
-                        "description" : "A systems user ID associated with this person. Different from personDbId because you could have a person who is not a user of the system.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "emailAddress",
+                    "in" : "query",
+                    "description" : "email address for this person",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "firstName",
+                    "in" : "query",
+                    "description" : "Persons first name",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "lastName",
+                    "in" : "query",
+                    "description" : "Persons last name",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "mailingAddress",
+                    "in" : "query",
+                    "description" : "physical address of this person",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "middleName",
+                    "in" : "query",
+                    "description" : "Persons middle name",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "personDbId",
+                    "in" : "query",
+                    "description" : "Unique ID for this person",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "phoneNumber",
+                    "in" : "query",
+                    "description" : "phone number of this person",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "userID",
+                    "in" : "query",
+                    "description" : "A systems user ID associated with this person. Different from personDbId because you could have a person who is not a user of the system.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/PersonListResponse"
@@ -535,16 +463,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "People"
-                ],
+                "tags" : [ "People" ],
                 "summary" : "Create new Person",
                 "description" : "Add new Person to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -572,107 +496,87 @@
         },
         "/programs" : {
             "get" : {
-                "tags" : [
-                    "Programs"
-                ],
+                "tags" : [ "Programs" ],
                 "summary" : "Get a filtered list of Program",
                 "description" : "Get a list of Program",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "abbreviation",
-                        "in" : "query",
-                        "description" : "A list of shortened human readable names for a set of Programs",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "leadPersonDbId",
-                        "in" : "query",
-                        "description" : "The person DbIds of the program leader to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "leadPersonName",
-                        "in" : "query",
-                        "description" : "The names of the program leader to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "objectife",
-                        "in" : "query",
-                        "description" : "A program objective to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programType",
-                        "in" : "query",
-                        "description" : "The type of program entity this object represents\n<br/> 'STANDARD' represents a standard, permanent breeding program\n<br/> 'PROJECT' represents a short term project, usually with a set time limit based on funding ",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string",
-                            "enum" : [
-                                "STANDARD",
-                                "PROJECT"
-                            ]
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "abbreviation",
+                    "in" : "query",
+                    "description" : "A list of shortened human readable names for a set of Programs",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "leadPersonDbId",
+                    "in" : "query",
+                    "description" : "The person DbIds of the program leader to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "leadPersonName",
+                    "in" : "query",
+                    "description" : "The names of the program leader to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "objectife",
+                    "in" : "query",
+                    "description" : "A program objective to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programType",
+                    "in" : "query",
+                    "description" : "The type of program entity this object represents\n<br/> 'STANDARD' represents a standard, permanent breeding program\n<br/> 'PROJECT' represents a short term project, usually with a set time limit based on funding ",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string",
+                        "enum" : [ "STANDARD", "PROJECT" ]
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/ProgramListResponse"
@@ -689,16 +593,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "Programs"
-                ],
+                "tags" : [ "Programs" ],
                 "summary" : "Create new Program",
                 "description" : "Add new Program to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -726,58 +626,48 @@
         },
         "/seasons" : {
             "get" : {
-                "tags" : [
-                    "Seasons"
-                ],
+                "tags" : [ "Seasons" ],
                 "summary" : "Get a filtered list of Season",
                 "description" : "Get a list of Season",
-                "parameters" : [
-                    {
-                        "name" : "seasonDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier for a season. For backward compatibility it can be a string like '2012', '1957-2004'.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "season",
-                        "in" : "query",
-                        "description" : "The term to describe a given season. Example \"Spring\" OR \"May\" OR \"Planting_Time_7\".",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "seasonName",
-                        "in" : "query",
-                        "description" : "The term to describe a given season. Example \"Spring\" OR \"May\" OR \"Planting_Time_7\".",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "year",
-                        "in" : "query",
-                        "description" : "The 4 digit year of a season. Example \"2017\"",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "seasonDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier for a season. For backward compatibility it can be a string like '2012', '1957-2004'.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "season",
+                    "in" : "query",
+                    "description" : "The term to describe a given season. Example \"Spring\" OR \"May\" OR \"Planting_Time_7\".",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "seasonName",
+                    "in" : "query",
+                    "description" : "The term to describe a given season. Example \"Spring\" OR \"May\" OR \"Planting_Time_7\".",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "year",
+                    "in" : "query",
+                    "description" : "The 4 digit year of a season. Example \"2017\"",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/SeasonListResponse"
@@ -794,16 +684,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "Seasons"
-                ],
+                "tags" : [ "Seasons" ],
                 "summary" : "Create new Season",
                 "description" : "Add new Season to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -831,202 +717,174 @@
         },
         "/studies" : {
             "get" : {
-                "tags" : [
-                    "Studies"
-                ],
+                "tags" : [ "Studies" ],
                 "summary" : "Get a filtered list of Study",
                 "description" : "Get a list of Study",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmDbId",
-                        "in" : "query",
-                        "description" : "List of IDs which uniquely identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmName",
-                        "in" : "query",
-                        "description" : "List of human readable names to identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "locationDbId",
-                        "in" : "query",
-                        "description" : "The location ids to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "locationName",
-                        "in" : "query",
-                        "description" : "A human readable names to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationVariableDbId",
-                        "in" : "query",
-                        "description" : "The DbIds of Variables to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationVariableName",
-                        "in" : "query",
-                        "description" : "The names of Variables to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationVariablePUI",
-                        "in" : "query",
-                        "description" : "The Permanent Unique Identifier of an Observation Variable, usually in the form of a URI",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "actife",
-                        "in" : "query",
-                        "description" : "A flag to indicate if a Study is currently active and ongoing",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "boolean"
-                        }
-                    },
-                    {
-                        "name" : "seasonDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a season",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyType",
-                        "in" : "query",
-                        "description" : "The type of study being performed. ex. \"Yield Trial\", etc",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyCode",
-                        "in" : "query",
-                        "description" : "A short human readable code for a study",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyPUI",
-                        "in" : "query",
-                        "description" : "Permanent unique identifier associated with study data. For example, a URI or DOI",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "germplasmDbId",
+                    "in" : "query",
+                    "description" : "List of IDs which uniquely identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmName",
+                    "in" : "query",
+                    "description" : "List of human readable names to identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "locationDbId",
+                    "in" : "query",
+                    "description" : "The location ids to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "locationName",
+                    "in" : "query",
+                    "description" : "A human readable names to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationVariableDbId",
+                    "in" : "query",
+                    "description" : "The DbIds of Variables to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationVariableName",
+                    "in" : "query",
+                    "description" : "The names of Variables to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationVariablePUI",
+                    "in" : "query",
+                    "description" : "The Permanent Unique Identifier of an Observation Variable, usually in the form of a URI",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "actife",
+                    "in" : "query",
+                    "description" : "A flag to indicate if a Study is currently active and ongoing",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "boolean"
+                    }
+                }, {
+                    "name" : "seasonDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a season",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyType",
+                    "in" : "query",
+                    "description" : "The type of study being performed. ex. \"Yield Trial\", etc",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyCode",
+                    "in" : "query",
+                    "description" : "A short human readable code for a study",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyPUI",
+                    "in" : "query",
+                    "description" : "Permanent unique identifier associated with study data. For example, a URI or DOI",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/StudyListResponse"
@@ -1043,16 +901,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "Studies"
-                ],
+                "tags" : [ "Studies" ],
                 "summary" : "Create new Study",
                 "description" : "Add new Study to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1080,184 +934,158 @@
         },
         "/trials" : {
             "get" : {
-                "tags" : [
-                    "Trials"
-                ],
+                "tags" : [ "Trials" ],
                 "summary" : "Get a filtered list of Trial",
                 "description" : "Get a list of Trial",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "locationDbId",
-                        "in" : "query",
-                        "description" : "The location ids to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "locationName",
-                        "in" : "query",
-                        "description" : "A human readable names to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationVariableDbId",
-                        "in" : "query",
-                        "description" : "The DbIds of Variables to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationVariableName",
-                        "in" : "query",
-                        "description" : "The names of Variables to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationVariablePUI",
-                        "in" : "query",
-                        "description" : "The Permanent Unique Identifier of an Observation Variable, usually in the form of a URI",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "actife",
-                        "in" : "query",
-                        "description" : "A flag to indicate if a Trial is currently active and ongoing",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "boolean"
-                        }
-                    },
-                    {
-                        "name" : "contactDbId",
-                        "in" : "query",
-                        "description" : "List of contact entities associated with this trial",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "searchDateRangeStart",
-                        "in" : "query",
-                        "description" : "The start of the overlapping search date range. `searchDateRangeStart` must be before `searchDateRangeEnd`.\n\nReturn a Trial entity if any of the following cases are true\n\n- `searchDateRangeStart` is before `trial.endDate` AND `searchDateRangeEnd` is null \n\n- `searchDateRangeStart` is before `trial.endDate` AND `searchDateRangeEnd` is after `trial.startDate`\n\n- `searchDateRangeEnd` is after `trial.startDate` AND `searchDateRangeStart` is null\n\n- `searchDateRangeEnd` is after `trial.startDate` AND `searchDateRangeStart` is before `trial.endDate`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "searchDateRangeEnd",
-                        "in" : "query",
-                        "description" : "The end of the overlapping search date range. `searchDateRangeStart` must be before `searchDateRangeEnd`.\n\nReturn a Trial entity if any of the following cases are true\n\n- `searchDateRangeStart` is before `trial.endDate` AND `searchDateRangeEnd` is null \n\n- `searchDateRangeStart` is before `trial.endDate` AND `searchDateRangeEnd` is after `trial.startDate`\n\n- `searchDateRangeEnd` is after `trial.startDate` AND `searchDateRangeStart` is null\n\n- `searchDateRangeEnd` is after `trial.startDate` AND `searchDateRangeStart` is before `trial.endDate`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialPUI",
-                        "in" : "query",
-                        "description" : "A permanent identifier for a trial. Could be DOI or other URI formatted identifier.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "locationDbId",
+                    "in" : "query",
+                    "description" : "The location ids to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "locationName",
+                    "in" : "query",
+                    "description" : "A human readable names to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationVariableDbId",
+                    "in" : "query",
+                    "description" : "The DbIds of Variables to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationVariableName",
+                    "in" : "query",
+                    "description" : "The names of Variables to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationVariablePUI",
+                    "in" : "query",
+                    "description" : "The Permanent Unique Identifier of an Observation Variable, usually in the form of a URI",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "actife",
+                    "in" : "query",
+                    "description" : "A flag to indicate if a Trial is currently active and ongoing",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "boolean"
+                    }
+                }, {
+                    "name" : "contactDbId",
+                    "in" : "query",
+                    "description" : "List of contact entities associated with this trial",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "searchDateRangeStart",
+                    "in" : "query",
+                    "description" : "The start of the overlapping search date range. `searchDateRangeStart` must be before `searchDateRangeEnd`.\n\nReturn a Trial entity if any of the following cases are true\n\n- `searchDateRangeStart` is before `trial.endDate` AND `searchDateRangeEnd` is null \n\n- `searchDateRangeStart` is before `trial.endDate` AND `searchDateRangeEnd` is after `trial.startDate`\n\n- `searchDateRangeEnd` is after `trial.startDate` AND `searchDateRangeStart` is null\n\n- `searchDateRangeEnd` is after `trial.startDate` AND `searchDateRangeStart` is before `trial.endDate`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "searchDateRangeEnd",
+                    "in" : "query",
+                    "description" : "The end of the overlapping search date range. `searchDateRangeStart` must be before `searchDateRangeEnd`.\n\nReturn a Trial entity if any of the following cases are true\n\n- `searchDateRangeStart` is before `trial.endDate` AND `searchDateRangeEnd` is null \n\n- `searchDateRangeStart` is before `trial.endDate` AND `searchDateRangeEnd` is after `trial.startDate`\n\n- `searchDateRangeEnd` is after `trial.startDate` AND `searchDateRangeStart` is null\n\n- `searchDateRangeEnd` is after `trial.startDate` AND `searchDateRangeStart` is before `trial.endDate`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialPUI",
+                    "in" : "query",
+                    "description" : "A permanent identifier for a trial. Could be DOI or other URI formatted identifier.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/TrialListResponse"
@@ -1274,16 +1102,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "Trials"
-                ],
+                "tags" : [ "Trials" ],
                 "summary" : "Create new Trial",
                 "description" : "Add new Trial to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1311,9 +1135,7 @@
         },
         "/lists/{listDbId}" : {
             "get" : {
-                "tags" : [
-                    "Lists"
-                ],
+                "tags" : [ "Lists" ],
                 "summary" : "Get the details of a specific List",
                 "description" : "Get details for a List",
                 "responses" : {
@@ -1332,16 +1154,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "Lists"
-                ],
+                "tags" : [ "Lists" ],
                 "summary" : "Update the details for an existing List",
                 "description" : "Update the details for an existing List",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1369,9 +1187,7 @@
         },
         "/locations/{locationDbId}" : {
             "get" : {
-                "tags" : [
-                    "Locations"
-                ],
+                "tags" : [ "Locations" ],
                 "summary" : "Get the details of a specific Location",
                 "description" : "Get details for a Location",
                 "responses" : {
@@ -1390,16 +1206,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "Locations"
-                ],
+                "tags" : [ "Locations" ],
                 "summary" : "Update the details for an existing Location",
                 "description" : "Update the details for an existing Location",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1427,9 +1239,7 @@
         },
         "/people/{personDbId}" : {
             "get" : {
-                "tags" : [
-                    "People"
-                ],
+                "tags" : [ "People" ],
                 "summary" : "Get the details of a specific Person",
                 "description" : "Get details for a Person",
                 "responses" : {
@@ -1448,16 +1258,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "People"
-                ],
+                "tags" : [ "People" ],
                 "summary" : "Update the details for an existing Person",
                 "description" : "Update the details for an existing Person",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1485,9 +1291,7 @@
         },
         "/programs/{programDbId}" : {
             "get" : {
-                "tags" : [
-                    "Programs"
-                ],
+                "tags" : [ "Programs" ],
                 "summary" : "Get the details of a specific Program",
                 "description" : "Get details for a Program",
                 "responses" : {
@@ -1506,16 +1310,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "Programs"
-                ],
+                "tags" : [ "Programs" ],
                 "summary" : "Update the details for an existing Program",
                 "description" : "Update the details for an existing Program",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1543,9 +1343,7 @@
         },
         "/seasons/{seasonDbId}" : {
             "get" : {
-                "tags" : [
-                    "Seasons"
-                ],
+                "tags" : [ "Seasons" ],
                 "summary" : "Get the details of a specific Season",
                 "description" : "Get details for a Season",
                 "responses" : {
@@ -1564,16 +1362,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "Seasons"
-                ],
+                "tags" : [ "Seasons" ],
                 "summary" : "Update the details for an existing Season",
                 "description" : "Update the details for an existing Season",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1601,9 +1395,7 @@
         },
         "/studies/{studyDbId}" : {
             "get" : {
-                "tags" : [
-                    "Studies"
-                ],
+                "tags" : [ "Studies" ],
                 "summary" : "Get the details of a specific Study",
                 "description" : "Get details for a Study",
                 "responses" : {
@@ -1622,16 +1414,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "Studies"
-                ],
+                "tags" : [ "Studies" ],
                 "summary" : "Update the details for an existing Study",
                 "description" : "Update the details for an existing Study",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1659,9 +1447,7 @@
         },
         "/trials/{trialDbId}" : {
             "get" : {
-                "tags" : [
-                    "Trials"
-                ],
+                "tags" : [ "Trials" ],
                 "summary" : "Get the details of a specific Trial",
                 "description" : "Get details for a Trial",
                 "responses" : {
@@ -1680,16 +1466,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "Trials"
-                ],
+                "tags" : [ "Trials" ],
                 "summary" : "Update the details for an existing Trial",
                 "description" : "Update the details for an existing Trial",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1717,9 +1499,7 @@
         },
         "/search/lists" : {
             "post" : {
-                "tags" : [
-                    "Lists"
-                ],
+                "tags" : [ "Lists" ],
                 "summary" : "Submit a search request for `List`",
                 "description" : "Submit a search request for `List`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/list/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -1743,9 +1523,7 @@
         },
         "/search/locations" : {
             "post" : {
-                "tags" : [
-                    "Locations"
-                ],
+                "tags" : [ "Locations" ],
                 "summary" : "Submit a search request for `Location`",
                 "description" : "Submit a search request for `Location`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/location/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -1769,9 +1547,7 @@
         },
         "/search/people" : {
             "post" : {
-                "tags" : [
-                    "People"
-                ],
+                "tags" : [ "People" ],
                 "summary" : "Submit a search request for `Person`",
                 "description" : "Submit a search request for `Person`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/person/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -1795,9 +1571,7 @@
         },
         "/search/programs" : {
             "post" : {
-                "tags" : [
-                    "Programs"
-                ],
+                "tags" : [ "Programs" ],
                 "summary" : "Submit a search request for `Program`",
                 "description" : "Submit a search request for `Program`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/program/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -1821,9 +1595,7 @@
         },
         "/search/studies" : {
             "post" : {
-                "tags" : [
-                    "Studies"
-                ],
+                "tags" : [ "Studies" ],
                 "summary" : "Submit a search request for `Study`",
                 "description" : "Submit a search request for `Study`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/study/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -1847,9 +1619,7 @@
         },
         "/search/trials" : {
             "post" : {
-                "tags" : [
-                    "Trials"
-                ],
+                "tags" : [ "Trials" ],
                 "summary" : "Submit a search request for `Trial`",
                 "description" : "Submit a search request for `Trial`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/trial/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -1873,9 +1643,7 @@
         },
         "/search/lists/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "Lists"
-                ],
+                "tags" : [ "Lists" ],
                 "summary" : "Submit a search request for `List`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/list/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `List` search request <br/>\nClients should submit a search request using the corresponding `POST /search/list` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -1896,9 +1664,7 @@
         },
         "/search/locations/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "Locations"
-                ],
+                "tags" : [ "Locations" ],
                 "summary" : "Submit a search request for `Location`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/location/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `Location` search request <br/>\nClients should submit a search request using the corresponding `POST /search/location` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -1919,9 +1685,7 @@
         },
         "/search/people/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "People"
-                ],
+                "tags" : [ "People" ],
                 "summary" : "Submit a search request for `Person`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/person/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `Person` search request <br/>\nClients should submit a search request using the corresponding `POST /search/person` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -1942,9 +1706,7 @@
         },
         "/search/programs/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "Programs"
-                ],
+                "tags" : [ "Programs" ],
                 "summary" : "Submit a search request for `Program`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/program/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `Program` search request <br/>\nClients should submit a search request using the corresponding `POST /search/program` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -1965,9 +1727,7 @@
         },
         "/search/studies/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "Studies"
-                ],
+                "tags" : [ "Studies" ],
                 "summary" : "Submit a search request for `Study`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/study/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `Study` search request <br/>\nClients should submit a search request using the corresponding `POST /search/study` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -1988,9 +1748,7 @@
         },
         "/search/trials/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "Trials"
-                ],
+                "tags" : [ "Trials" ],
                 "summary" : "Submit a search request for `Trial`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/trial/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `Trial` search request <br/>\nClients should submit a search request using the corresponding `POST /search/trial` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2022,12 +1780,7 @@
                 "description" : "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification."
             },
             "Attribute" : {
-                "required" : [
-                    "attributeName",
-                    "method",
-                    "scale",
-                    "trait"
-                ],
+                "required" : [ "attributeName", "method", "scale", "trait" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -2108,9 +1861,7 @@
                 }
             },
             "Contact" : {
-                "required" : [
-                    "contactDbId"
-                ],
+                "required" : [ "contactDbId" ],
                 "type" : "object",
                 "properties" : {
                     "contactDbId" : {
@@ -2135,20 +1886,13 @@
             },
             "ContentTypes" : {
                 "type" : "string",
-                "enum" : [
-                    "application/json",
-                    "text/csv",
-                    "text/tsv",
-                    "application/flapjack"
-                ]
+                "enum" : [ "application/json", "text/csv", "text/tsv", "application/flapjack" ]
             },
             "Context" : {
                 "title" : "context",
                 "type" : "array",
                 "description" : "The JSON-LD Context is used to provide JSON-LD definitions to each field in a JSON object. By providing an array of context file urls, a BrAPI response object becomes JSON-LD compatible.  \n\nFor more information, see https://w3c.github.io/json-ld-syntax/#the-context",
-                "example" : [
-                    "https://brapi.org/jsonld/context/metadata.jsonld"
-                ],
+                "example" : [ "https://brapi.org/jsonld/context/metadata.jsonld" ],
                 "items" : {
                     "type" : "string",
                     "format" : "uri"
@@ -2207,52 +1951,43 @@
                 "description" : "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.\n\nCopied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
             },
             "GeoJSONGeometry" : {
-                "oneOf" : [
-                    {
-                        "required" : [
-                            "coordinateDbIds",
-                            "type"
-                        ],
-                        "type" : "object",
-                        "properties" : {
-                            "coordinates" : {
-                                "type" : "array",
-                                "items" : {
-                                    "type" : "number"
-                                }
-                            },
-                            "type" : {
-                                "type" : "string"
+                "oneOf" : [ {
+                    "required" : [ "coordinateDbIds", "type" ],
+                    "type" : "object",
+                    "properties" : {
+                        "coordinates" : {
+                            "type" : "array",
+                            "items" : {
+                                "type" : "number"
                             }
                         },
-                        "description" : "Copied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
+                        "type" : {
+                            "type" : "string"
+                        }
                     },
-                    {
-                        "required" : [
-                            "coordinateDbIds",
-                            "type"
-                        ],
-                        "type" : "object",
-                        "properties" : {
-                            "coordinates" : {
+                    "description" : "Copied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
+                }, {
+                    "required" : [ "coordinateDbIds", "type" ],
+                    "type" : "object",
+                    "properties" : {
+                        "coordinates" : {
+                            "type" : "array",
+                            "items" : {
                                 "type" : "array",
                                 "items" : {
                                     "type" : "array",
                                     "items" : {
-                                        "type" : "array",
-                                        "items" : {
-                                            "type" : "number"
-                                        }
+                                        "type" : "number"
                                     }
                                 }
-                            },
-                            "type" : {
-                                "type" : "string"
                             }
                         },
-                        "description" : "An array of Linear Rings. Each Linear Ring is an array of Points. \n\nA Point is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
-                    }
-                ]
+                        "type" : {
+                            "type" : "string"
+                        }
+                    },
+                    "description" : "An array of Linear Rings. Each Linear Ring is an array of Points. \n\nA Point is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
+                } ]
             },
             "GeoJSONSearchArea" : {
                 "type" : "object",
@@ -2266,11 +2001,7 @@
                 }
             },
             "List" : {
-                "required" : [
-                    "listDbId",
-                    "listName",
-                    "listType"
-                ],
+                "required" : [ "listDbId", "listName", "listType" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -2307,12 +2038,7 @@
                 }
             },
             "ListNewRequest" : {
-                "required" : [
-                    "listDbId",
-                    "listDbId",
-                    "listName",
-                    "listType"
-                ],
+                "required" : [ "listDbId", "listDbId", "listName", "listType" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -2374,24 +2100,10 @@
             "ListType" : {
                 "type" : "string",
                 "description" : "The type of objects that are referenced in a List",
-                "enum" : [
-                    "germplasm",
-                    "markers",
-                    "variants",
-                    "programs",
-                    "trials",
-                    "studies",
-                    "observationUnits",
-                    "observations",
-                    "observationVariables",
-                    "samples"
-                ]
+                "enum" : [ "germplasm", "markers", "variants", "programs", "trials", "studies", "observationUnits", "observations", "observationVariables", "samples" ]
             },
             "Location" : {
-                "required" : [
-                    "locationDbId",
-                    "locationName"
-                ],
+                "required" : [ "locationDbId", "locationName" ],
                 "type" : "object",
                 "properties" : {
                     "abbreviation" : {
@@ -2457,11 +2169,7 @@
                 }
             },
             "LocationNewRequest" : {
-                "required" : [
-                    "locationDbId",
-                    "locationDbId",
-                    "locationName"
-                ],
+                "required" : [ "locationDbId", "locationDbId", "locationName" ],
                 "type" : "object",
                 "properties" : {
                     "abbreviation" : {
@@ -2541,9 +2249,7 @@
                 }
             },
             "Person" : {
-                "required" : [
-                    "personDbId"
-                ],
+                "required" : [ "personDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -2576,10 +2282,7 @@
                 }
             },
             "PersonNewRequest" : {
-                "required" : [
-                    "personDbId",
-                    "personDbId"
-                ],
+                "required" : [ "personDbId", "personDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -2619,10 +2322,7 @@
                 "properties" : { }
             },
             "Program" : {
-                "required" : [
-                    "programDbId",
-                    "programName"
-                ],
+                "required" : [ "programDbId", "programName" ],
                 "type" : "object",
                 "properties" : {
                     "abbreviation" : {
@@ -2652,19 +2352,12 @@
                     "programType" : {
                         "type" : "string",
                         "description" : "The type of program entity this object represents\n<br/> 'STANDARD' represents a standard, permanent breeding program\n<br/> 'PROJECT' represents a short term project, usually with a set time limit based on funding   ",
-                        "enum" : [
-                            "STANDARD",
-                            "PROJECT"
-                        ]
+                        "enum" : [ "STANDARD", "PROJECT" ]
                     }
                 }
             },
             "ProgramNewRequest" : {
-                "required" : [
-                    "programDbId",
-                    "programDbId",
-                    "programName"
-                ],
+                "required" : [ "programDbId", "programDbId", "programName" ],
                 "type" : "object",
                 "properties" : {
                     "abbreviation" : {
@@ -2697,10 +2390,7 @@
                     "programType" : {
                         "type" : "string",
                         "description" : "The type of program entity this object represents\n<br/> 'STANDARD' represents a standard, permanent breeding program\n<br/> 'PROJECT' represents a short term project, usually with a set time limit based on funding   ",
-                        "enum" : [
-                            "STANDARD",
-                            "PROJECT"
-                        ]
+                        "enum" : [ "STANDARD", "PROJECT" ]
                     }
                 }
             },
@@ -2709,9 +2399,7 @@
                 "properties" : { }
             },
             "Season" : {
-                "required" : [
-                    "seasonDbId"
-                ],
+                "required" : [ "seasonDbId" ],
                 "type" : "object",
                 "properties" : {
                     "seasonDbId" : {
@@ -2727,10 +2415,7 @@
                 }
             },
             "Study" : {
-                "required" : [
-                    "studyDbId",
-                    "studyName"
-                ],
+                "required" : [ "studyDbId", "studyName" ],
                 "type" : "object",
                 "properties" : {
                     "active" : {
@@ -2841,11 +2526,7 @@
                 }
             },
             "StudyNewRequest" : {
-                "required" : [
-                    "studyDbId",
-                    "studyDbId",
-                    "studyName"
-                ],
+                "required" : [ "studyDbId", "studyDbId", "studyName" ],
                 "type" : "object",
                 "properties" : {
                     "active" : {
@@ -2969,21 +2650,10 @@
             "TraitDataType" : {
                 "type" : "string",
                 "description" : "<p>Class of the scale, entries can be</p>\n<p>\"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal scale that combines the expressions of the different traits composing the complex trait. For example a severity trait might be expressed by a 2 digit and 2 character code. The first 2 digits are the percentage of the plant covered by a fungus and the 2 characters refer to the delay in development, e.g. \"75VD\" means \"75 %\" of the plant is infected and the plant is very delayed.</p>\n<p>\"Date\" - The date class is for events expressed in a time format, See ISO 8601</p>\n<p>\"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months</p>\n<p>\"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories</p>\n<p>\"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectare, branches</p>\n<p>\"Ordinal\" - Ordinal scales are scales composed of ordered categories</p>\n<p>\"Text\" - A free text is used to express the trait.</p>",
-                "enum" : [
-                    "Code",
-                    "Date",
-                    "Duration",
-                    "Nominal",
-                    "Numerical",
-                    "Ordinal",
-                    "Text"
-                ]
+                "enum" : [ "Code", "Date", "Duration", "Nominal", "Numerical", "Ordinal", "Text" ]
             },
             "Trial" : {
-                "required" : [
-                    "trialDbId",
-                    "trialName"
-                ],
+                "required" : [ "trialDbId", "trialName" ],
                 "type" : "object",
                 "properties" : {
                     "active" : {
@@ -3034,11 +2704,7 @@
                 }
             },
             "TrialNewRequest" : {
-                "required" : [
-                    "trialDbId",
-                    "trialDbId",
-                    "trialName"
-                ],
+                "required" : [ "trialDbId", "trialDbId", "trialName" ],
                 "type" : "object",
                 "properties" : {
                     "active" : {
@@ -3106,11 +2772,7 @@
                 }
             },
             "Variable" : {
-                "required" : [
-                    "method",
-                    "scale",
-                    "trait"
-                ],
+                "required" : [ "method", "scale", "trait" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3176,10 +2838,7 @@
                 }
             },
             "basePagination" : {
-                "required" : [
-                    "currentPage",
-                    "pageSize"
-                ],
+                "required" : [ "currentPage", "pageSize" ],
                 "type" : "object",
                 "properties" : {
                     "currentPage" : {
@@ -3208,9 +2867,7 @@
                 "description" : "The pagination object is applicable only when the payload contains a \"data\" key. It describes the pagination of the data contained in the \"data\" array, as a way to identify which subset of data is being returned. \n<br> Pages are zero indexed, so the first page will be page 0 (zero)."
             },
             "dataFile" : {
-                "required" : [
-                    "fileURL"
-                ],
+                "required" : [ "fileURL" ],
                 "type" : "object",
                 "properties" : {
                     "fileURL" : {
@@ -3248,19 +2905,16 @@
                 "description" : "A dataFile contains a URL and the relevant file metadata to represent a file"
             },
             "metadata" : {
-                "allOf" : [
-                    {
-                        "$ref" : "#/components/schemas/metadataBase"
-                    },
-                    {
-                        "type" : "object",
-                        "properties" : {
-                            "pagination" : {
-                                "$ref" : "#/components/schemas/basePagination"
-                            }
+                "allOf" : [ {
+                    "$ref" : "#/components/schemas/metadataBase"
+                }, {
+                    "type" : "object",
+                    "properties" : {
+                        "pagination" : {
+                            "$ref" : "#/components/schemas/basePagination"
                         }
                     }
-                ]
+                } ]
             },
             "metadataBase" : {
                 "type" : "object",
@@ -3284,25 +2938,19 @@
                 "description" : "An object in the BrAPI standard response model that describes some information about the service call being performed. This includes supplementary data, status log messages, and pagination information."
             },
             "metadataTokenPagination" : {
-                "allOf" : [
-                    {
-                        "$ref" : "#/components/schemas/metadataBase"
-                    },
-                    {
-                        "type" : "object",
-                        "properties" : {
-                            "pagination" : {
-                                "$ref" : "#/components/schemas/tokenPagination"
-                            }
+                "allOf" : [ {
+                    "$ref" : "#/components/schemas/metadataBase"
+                }, {
+                    "type" : "object",
+                    "properties" : {
+                        "pagination" : {
+                            "$ref" : "#/components/schemas/tokenPagination"
                         }
                     }
-                ]
+                } ]
             },
             "status" : {
-                "required" : [
-                    "message",
-                    "messageType"
-                ],
+                "required" : [ "message", "messageType" ],
                 "type" : "object",
                 "properties" : {
                     "message" : {
@@ -3314,133 +2962,56 @@
                         "type" : "string",
                         "description" : "The logging level for the attached message",
                         "example" : "INFO",
-                        "enum" : [
-                            "DEBUG",
-                            "ERROR",
-                            "WARNING",
-                            "INFO"
-                        ]
+                        "enum" : [ "DEBUG", "ERROR", "WARNING", "INFO" ]
                     }
                 },
                 "description" : "An array of status messages to convey technical logging information from the server to the client."
             },
             "tokenPagination" : {
-                "allOf" : [
-                    {
-                        "$ref" : "#/components/schemas/basePagination"
-                    },
-                    {
-                        "required" : [
-                            "nextPageToken"
-                        ],
-                        "type" : "object",
-                        "properties" : {
-                            "nextPageToken" : {
-                                "type" : "string",
-                                "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the next page of data.",
-                                "example" : "cb668f63",
-                                "deprecated" : true
-                            },
-                            "currentPageToken" : {
-                                "type" : "string",
-                                "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the current page of data.",
-                                "example" : "48bc6ac1",
-                                "deprecated" : true
-                            },
-                            "prevPageToken" : {
-                                "type" : "string",
-                                "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the previous page of data.",
-                                "example" : "9659857e",
-                                "deprecated" : true
-                            }
+                "allOf" : [ {
+                    "$ref" : "#/components/schemas/basePagination"
+                }, {
+                    "required" : [ "nextPageToken" ],
+                    "type" : "object",
+                    "properties" : {
+                        "nextPageToken" : {
+                            "type" : "string",
+                            "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the next page of data.",
+                            "example" : "cb668f63",
+                            "deprecated" : true
                         },
-                        "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The pagination object is applicable only when the payload contains a \"data\" key. It describes the pagination of the data contained in the \"data\" array, as a way to identify which subset of data is being returned. \n<br>Tokenized pages are for large data sets which can not be efficiently broken into indexed pages. Use the nextPageToken and prevPageToken to construct an additional query and move to the next or previous page respectively.  ",
-                        "example" : {
-                            "currentPage" : 0,
-                            "pageSize" : 1000,
-                            "totalCount" : 10,
-                            "totalPages" : 1
+                        "currentPageToken" : {
+                            "type" : "string",
+                            "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the current page of data.",
+                            "example" : "48bc6ac1",
+                            "deprecated" : true
+                        },
+                        "prevPageToken" : {
+                            "type" : "string",
+                            "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the previous page of data.",
+                            "example" : "9659857e",
+                            "deprecated" : true
                         }
+                    },
+                    "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The pagination object is applicable only when the payload contains a \"data\" key. It describes the pagination of the data contained in the \"data\" array, as a way to identify which subset of data is being returned. \n<br>Tokenized pages are for large data sets which can not be efficiently broken into indexed pages. Use the nextPageToken and prevPageToken to construct an additional query and move to the next or previous page respectively.  ",
+                    "example" : {
+                        "currentPage" : 0,
+                        "pageSize" : 1000,
+                        "totalCount" : 10,
+                        "totalPages" : 1
                     }
-                ]
+                } ]
             }
         },
         "responses" : {
-            "ObservationVariableSingleResponse" : {
-                "description" : "OK",
+            "401Unauthorized" : {
+                "description" : "Unauthorized",
                 "content" : {
                     "application/json" : {
                         "schema" : {
-                            "title" : "ObservationVariableSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/ObservationVariable"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "SeedLotSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "SeedLotSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/SeedLot"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "VariantSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "VariantSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Variant"
-                                }
-                            }
-                        }
+                            "type" : "string"
+                        },
+                        "example" : "ERROR - 2018-10-08T18:15:11Z - Missing or expired authorization token"
                     }
                 }
             },
@@ -3478,10 +3049,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "StudySingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -3498,679 +3066,13 @@
                     }
                 }
             },
-            "MarkerPositionListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "MarkerPositionListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/MarkerPosition"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "TrialListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "TrialListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Trial"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "MethodSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "MethodSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Method"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "SeedLotListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "SeedLotListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/SeedLot"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "VariantSetListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "VariantSetListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/VariantSet"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "SampleSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "SampleSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Sample"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "CallSetListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "CallSetListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/CallSet"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "CallSetSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "CallSetSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/CallSet"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "VariantSetSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "VariantSetSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/VariantSet"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ReferenceSetSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ReferenceSetSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/ReferenceSet"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ObservationVariableListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ObservationVariableListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/ObservationVariable"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "CrossListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "CrossListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Cross"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ImageSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ImageSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Image"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "PlateListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "PlateListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Plate"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "SeasonListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "SeasonListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Season"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ObservationUnitListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ObservationUnitListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/ObservationUnit"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ReferenceListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ReferenceListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Reference"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ObservationListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ObservationListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Observation"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "AlleleMatrixListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "AlleleMatrixListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/AlleleMatrix"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "GenomeMapSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "GenomeMapSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/GenomeMap"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "PersonListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "PersonListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4180,9 +3082,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4198,16 +3098,13 @@
                     }
                 }
             },
-            "PlannedCrossListResponse" : {
+            "LocationListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
-                            "title" : "PlannedCrossListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "title" : "LocationListResponse",
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4217,15 +3114,13 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
                                             "type" : "array",
                                             "items" : {
-                                                "$ref" : "#/components/schemas/PlannedCross"
+                                                "$ref" : "#/components/schemas/Location"
                                             }
                                         }
                                     }
@@ -4235,16 +3130,13 @@
                     }
                 }
             },
-            "LocationListResponse" : {
+            "TrialListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
-                            "title" : "LocationListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "title" : "TrialListResponse",
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4254,15 +3146,13 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
                                             "type" : "array",
                                             "items" : {
-                                                "$ref" : "#/components/schemas/Location"
+                                                "$ref" : "#/components/schemas/Trial"
                                             }
                                         }
                                     }
@@ -4283,42 +3173,13 @@
                     }
                 }
             },
-            "OntologySingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "OntologySingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Ontology"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "ProgramListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "ProgramListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4328,9 +3189,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4346,512 +3205,13 @@
                     }
                 }
             },
-            "ObservationUnitSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ObservationUnitSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/ObservationUnit"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ScaleListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ScaleListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Scale"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ListListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ListListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/List"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "400BadRequest" : {
-                "description" : "Bad Request",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "type" : "string"
-                        },
-                        "example" : "ERROR - 2018-10-08T18:15:11Z - Malformed JSON Request Object\n\nERROR - 2018-10-08T18:15:11Z - Invalid query parameter\n\nERROR - 2018-10-08T18:15:11Z - Required parameter is missing"
-                    }
-                }
-            },
-            "MethodListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "MethodListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Method"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "CrossingProjectListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "CrossingProjectListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/CrossingProject"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "GermplasmAttributeSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "GermplasmAttributeSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/GermplasmAttribute"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "TraitSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "TraitSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Trait"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "401Unauthorized" : {
-                "description" : "Unauthorized",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "type" : "string"
-                        },
-                        "example" : "ERROR - 2018-10-08T18:15:11Z - Missing or expired authorization token"
-                    }
-                }
-            },
-            "GermplasmAttributeListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "GermplasmAttributeListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/GermplasmAttribute"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "GermplasmListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "GermplasmListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Germplasm"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "CrossingProjectSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "CrossingProjectSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/CrossingProject"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "EventListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "EventListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Event"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "TraitListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "TraitListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Trait"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "SampleListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "SampleListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Sample"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ReferenceSetListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ReferenceSetListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/ReferenceSet"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "TrialSingleResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "TrialSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4868,16 +3228,13 @@
                     }
                 }
             },
-            "GermplasmSingleResponse" : {
+            "ListListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
-                            "title" : "GermplasmSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "title" : "ListListResponse",
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4887,7 +3244,16 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "$ref" : "#/components/schemas/Germplasm"
+                                    "required" : [ "data" ],
+                                    "type" : "object",
+                                    "properties" : {
+                                        "data" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/List"
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -4900,10 +3266,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "SeasonSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4920,66 +3283,14 @@
                     }
                 }
             },
-            "ReferenceSingleResponse" : {
-                "description" : "OK",
+            "400BadRequest" : {
+                "description" : "Bad Request",
                 "content" : {
                     "application/json" : {
                         "schema" : {
-                            "title" : "ReferenceSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Reference"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "OntologyListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "OntologyListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Ontology"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
+                            "type" : "string"
+                        },
+                        "example" : "ERROR - 2018-10-08T18:15:11Z - Malformed JSON Request Object\n\nERROR - 2018-10-08T18:15:11Z - Invalid query parameter\n\nERROR - 2018-10-08T18:15:11Z - Required parameter is missing"
                     }
                 }
             },
@@ -5000,10 +3311,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "StudyListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5013,9 +3321,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5031,105 +3337,13 @@
                     }
                 }
             },
-            "ScaleSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ScaleSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Scale"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "BreedingMethodSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "BreedingMethodSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/BreedingMethod"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "CallListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "CallListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Call"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "LocationSingleResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "LocationSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5146,16 +3360,13 @@
                     }
                 }
             },
-            "PersonSingleResponse" : {
+            "SeasonListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
-                            "title" : "PersonSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "title" : "SeasonListResponse",
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5165,307 +3376,16 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "$ref" : "#/components/schemas/Person"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ImageListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ImageListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
                                             "type" : "array",
                                             "items" : {
-                                                "$ref" : "#/components/schemas/Image"
+                                                "$ref" : "#/components/schemas/Season"
                                             }
                                         }
                                     }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "VariantListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "VariantListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Variant"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "PlateSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "PlateSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Plate"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "GermplasmAttributeValueListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "GermplasmAttributeValueListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/GermplasmAttributeValue"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "BreedingMethodListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "BreedingMethodListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/BreedingMethod"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "GermplasmAttributeValueSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "GermplasmAttributeValueSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/GermplasmAttributeValue"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "GenomeMapListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "GenomeMapListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/GenomeMap"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "PedigreeNodeListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "PedigreeNodeListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/PedigreeNode"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ObservationSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ObservationSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Observation"
                                 }
                             }
                         }
@@ -5478,10 +3398,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ListSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5498,16 +3415,36 @@
                     }
                 }
             },
+            "PersonSingleResponse" : {
+                "description" : "OK",
+                "content" : {
+                    "application/json" : {
+                        "schema" : {
+                            "title" : "PersonSingleResponse",
+                            "required" : [ "metadata", "result" ],
+                            "type" : "object",
+                            "properties" : {
+                                "@context" : {
+                                    "$ref" : "#/components/schemas/Context"
+                                },
+                                "metadata" : {
+                                    "$ref" : "#/components/schemas/metadata"
+                                },
+                                "result" : {
+                                    "$ref" : "#/components/schemas/Person"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
             "ProgramSingleResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "ProgramSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {

--- a/java/core/src/test/resources/OpenAPIGenerator/BrAPI-Genotyping.json
+++ b/java/core/src/test/resources/OpenAPIGenerator/BrAPI-Genotyping.json
@@ -7,85 +7,72 @@
     "paths" : {
         "/calls" : {
             "get" : {
-                "tags" : [
-                    "Calls"
-                ],
+                "tags" : [ "Calls" ],
                 "summary" : "Get a filtered list of Call",
                 "description" : "Get a list of Call",
-                "parameters" : [
-                    {
-                        "name" : "callSetDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `CallSets` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "variantDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `Variant` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "variantSetDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `VariantSets` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "expandHomozygote",
-                        "in" : "query",
-                        "description" : "Should homozygotes be expanded (true) or collapsed into a single occurrence (false)",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "boolean"
-                        }
-                    },
-                    {
-                        "name" : "sepPhased",
-                        "in" : "query",
-                        "description" : "The string used as a separator for phased allele calls.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "sepUnphased",
-                        "in" : "query",
-                        "description" : "The string used as a separator for unphased allele calls.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "unknownString",
-                        "in" : "query",
-                        "description" : "The string used as a representation for missing data.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "callSetDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `CallSets` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "variantDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `Variant` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "variantSetDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `VariantSets` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "expandHomozygote",
+                    "in" : "query",
+                    "description" : "Should homozygotes be expanded (true) or collapsed into a single occurrence (false)",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "boolean"
+                    }
+                }, {
+                    "name" : "sepPhased",
+                    "in" : "query",
+                    "description" : "The string used as a separator for phased allele calls.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "sepUnphased",
+                    "in" : "query",
+                    "description" : "The string used as a separator for unphased allele calls.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "unknownString",
+                    "in" : "query",
+                    "description" : "The string used as a representation for missing data.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/CallListResponse"
@@ -104,157 +91,134 @@
         },
         "/callsets" : {
             "get" : {
-                "tags" : [
-                    "CallSets"
-                ],
+                "tags" : [ "CallSets" ],
                 "summary" : "Get a filtered list of CallSet",
                 "description" : "Get a list of CallSet",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmDbId",
-                        "in" : "query",
-                        "description" : "List of IDs which uniquely identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmName",
-                        "in" : "query",
-                        "description" : "List of human readable names to identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "sampleDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `Samples` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "sampleName",
-                        "in" : "query",
-                        "description" : "A list of human readable names associated with `Samples`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "callSetDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `CallSets` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "callSetName",
-                        "in" : "query",
-                        "description" : "A list of human readable names associated with `CallSets`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "variantSetDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `VariantSets` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "germplasmDbId",
+                    "in" : "query",
+                    "description" : "List of IDs which uniquely identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmName",
+                    "in" : "query",
+                    "description" : "List of human readable names to identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "sampleDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `Samples` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "sampleName",
+                    "in" : "query",
+                    "description" : "A list of human readable names associated with `Samples`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "callSetDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `CallSets` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "callSetName",
+                    "in" : "query",
+                    "description" : "A list of human readable names associated with `CallSets`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "variantSetDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `VariantSets` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/CallSetListResponse"
@@ -273,121 +237,104 @@
         },
         "/maps" : {
             "get" : {
-                "tags" : [
-                    "GenomeMaps"
-                ],
+                "tags" : [ "GenomeMaps" ],
                 "summary" : "Get a filtered list of GenomeMap",
                 "description" : "Get a list of GenomeMap",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "mapDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a `GenomeMap`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "mapPUI",
-                        "in" : "query",
-                        "description" : "The DOI or other permanent identifier for a `GenomeMap`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "scientificName",
-                        "in" : "query",
-                        "description" : "Full scientific binomial format name. This includes Genus, Species, and Sub-species",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "type",
-                        "in" : "query",
-                        "description" : "The type of map, usually \"Genetic\" or \"Physical\"",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "mapDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a `GenomeMap`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "mapPUI",
+                    "in" : "query",
+                    "description" : "The DOI or other permanent identifier for a `GenomeMap`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "scientificName",
+                    "in" : "query",
+                    "description" : "Full scientific binomial format name. This includes Genus, Species, and Sub-species",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "type",
+                    "in" : "query",
+                    "description" : "The type of map, usually \"Genetic\" or \"Physical\"",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/GenomeMapListResponse"
@@ -406,69 +353,58 @@
         },
         "/markerpositions" : {
             "get" : {
-                "tags" : [
-                    "MarkerPositions"
-                ],
+                "tags" : [ "MarkerPositions" ],
                 "summary" : "Get a filtered list of MarkerPosition",
                 "description" : "Get a list of MarkerPosition",
-                "parameters" : [
-                    {
-                        "name" : "mapDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `GenomeMaps` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "linkageGroupName",
-                        "in" : "query",
-                        "description" : "A list of Uniquely Identifiable linkage group names",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "variantDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `Variants` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "minPosition",
-                        "in" : "query",
-                        "description" : "The minimum position of markers in a given map",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "integer",
-                            "format" : "int32"
-                        }
-                    },
-                    {
-                        "name" : "maxPosition",
-                        "in" : "query",
-                        "description" : "The maximum position of markers in a given map",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "integer",
-                            "format" : "int32"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "mapDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `GenomeMaps` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "linkageGroupName",
+                    "in" : "query",
+                    "description" : "A list of Uniquely Identifiable linkage group names",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "variantDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `Variants` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "minPosition",
+                    "in" : "query",
+                    "description" : "The minimum position of markers in a given map",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "integer",
+                        "format" : "int32"
+                    }
+                }, {
+                    "name" : "maxPosition",
+                    "in" : "query",
+                    "description" : "The maximum position of markers in a given map",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "integer",
+                        "format" : "int32"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/MarkerPositionListResponse"
@@ -487,184 +423,158 @@
         },
         "/plates" : {
             "get" : {
-                "tags" : [
-                    "Plates"
-                ],
+                "tags" : [ "Plates" ],
                 "summary" : "Get a filtered list of Plate",
                 "description" : "Get a list of Plate",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmDbId",
-                        "in" : "query",
-                        "description" : "List of IDs which uniquely identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmName",
-                        "in" : "query",
-                        "description" : "List of human readable names to identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationUnitDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies an observation unit",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "plateDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a plate of samples",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "plateName",
-                        "in" : "query",
-                        "description" : "The human readable name of a plate of samples",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "plateBarcode",
-                        "in" : "query",
-                        "description" : "A unique identifier physically attached to the plate",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "sampleDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a sample",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "sampleName",
-                        "in" : "query",
-                        "description" : "The human readable name of the sample",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "sampleGroupDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier for a group of related Samples",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a germplasm",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "germplasmDbId",
+                    "in" : "query",
+                    "description" : "List of IDs which uniquely identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmName",
+                    "in" : "query",
+                    "description" : "List of human readable names to identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationUnitDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies an observation unit",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "plateDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a plate of samples",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "plateName",
+                    "in" : "query",
+                    "description" : "The human readable name of a plate of samples",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "plateBarcode",
+                    "in" : "query",
+                    "description" : "A unique identifier physically attached to the plate",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "sampleDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a sample",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "sampleName",
+                    "in" : "query",
+                    "description" : "The human readable name of the sample",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "sampleGroupDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier for a group of related Samples",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a germplasm",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/PlateListResponse"
@@ -681,16 +591,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "Plates"
-                ],
+                "tags" : [ "Plates" ],
                 "summary" : "Create new Plate",
                 "description" : "Add new Plate to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -718,177 +624,152 @@
         },
         "/references" : {
             "get" : {
-                "tags" : [
-                    "References"
-                ],
+                "tags" : [ "References" ],
                 "summary" : "Get a filtered list of Reference",
                 "description" : "Get a list of Reference",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmDbId",
-                        "in" : "query",
-                        "description" : "List of IDs which uniquely identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmName",
-                        "in" : "query",
-                        "description" : "List of human readable names to identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "accession",
-                        "in" : "query",
-                        "description" : "If specified, return the references for which the `accession` matches this string (case-sensitive, exact match).",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "md5checksum",
-                        "in" : "query",
-                        "description" : "If specified, return the references for which the `md5checksum` matches this string (case-sensitive, exact match).",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "referenceDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `References` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "referenceSetDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `ReferenceSets` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "isDerived",
-                        "in" : "query",
-                        "description" : "A sequence X is said to be derived from source sequence Y, if X and Y are of the same length and the per-base sequence divergence at A/C/G/T bases is sufficiently small. Two sequences derived from the same official sequence share the same coordinates and annotations, and can be replaced with the official sequence for certain use cases.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "boolean"
-                        }
-                    },
-                    {
-                        "name" : "minLength",
-                        "in" : "query",
-                        "description" : "The minimum length of this `References` sequence.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "integer",
-                            "format" : "int32"
-                        }
-                    },
-                    {
-                        "name" : "maxLength",
-                        "in" : "query",
-                        "description" : "The minimum length of this `References` sequence.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "integer",
-                            "format" : "int32"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "germplasmDbId",
+                    "in" : "query",
+                    "description" : "List of IDs which uniquely identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmName",
+                    "in" : "query",
+                    "description" : "List of human readable names to identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "accession",
+                    "in" : "query",
+                    "description" : "If specified, return the references for which the `accession` matches this string (case-sensitive, exact match).",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "md5checksum",
+                    "in" : "query",
+                    "description" : "If specified, return the references for which the `md5checksum` matches this string (case-sensitive, exact match).",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "referenceDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `References` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "referenceSetDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `ReferenceSets` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "isDerived",
+                    "in" : "query",
+                    "description" : "A sequence X is said to be derived from source sequence Y, if X and Y are of the same length and the per-base sequence divergence at A/C/G/T bases is sufficiently small. Two sequences derived from the same official sequence share the same coordinates and annotations, and can be replaced with the official sequence for certain use cases.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "boolean"
+                    }
+                }, {
+                    "name" : "minLength",
+                    "in" : "query",
+                    "description" : "The minimum length of this `References` sequence.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "integer",
+                        "format" : "int32"
+                    }
+                }, {
+                    "name" : "maxLength",
+                    "in" : "query",
+                    "description" : "The minimum length of this `References` sequence.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "integer",
+                        "format" : "int32"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/ReferenceListResponse"
@@ -907,148 +788,126 @@
         },
         "/referencesets" : {
             "get" : {
-                "tags" : [
-                    "ReferenceSets"
-                ],
+                "tags" : [ "ReferenceSets" ],
                 "summary" : "Get a filtered list of ReferenceSet",
                 "description" : "Get a list of ReferenceSet",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmDbId",
-                        "in" : "query",
-                        "description" : "List of IDs which uniquely identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmName",
-                        "in" : "query",
-                        "description" : "List of human readable names to identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "accession",
-                        "in" : "query",
-                        "description" : "If set, return the reference sets for which the `accession` matches this string (case-sensitive, exact match).",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "assemblyPUI",
-                        "in" : "query",
-                        "description" : "If set, return the reference sets for which the `assemblyId` matches this string (case-sensitive, exact match).",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "md5checksum",
-                        "in" : "query",
-                        "description" : "If set, return the reference sets for which the `md5checksum` matches this string (case-sensitive, exact match).",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "referenceSetDbId",
-                        "in" : "query",
-                        "description" : "The `ReferenceSets` to search.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "germplasmDbId",
+                    "in" : "query",
+                    "description" : "List of IDs which uniquely identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmName",
+                    "in" : "query",
+                    "description" : "List of human readable names to identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "accession",
+                    "in" : "query",
+                    "description" : "If set, return the reference sets for which the `accession` matches this string (case-sensitive, exact match).",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "assemblyPUI",
+                    "in" : "query",
+                    "description" : "If set, return the reference sets for which the `assemblyId` matches this string (case-sensitive, exact match).",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "md5checksum",
+                    "in" : "query",
+                    "description" : "If set, return the reference sets for which the `md5checksum` matches this string (case-sensitive, exact match).",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "referenceSetDbId",
+                    "in" : "query",
+                    "description" : "The `ReferenceSets` to search.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/ReferenceSetListResponse"
@@ -1067,175 +926,150 @@
         },
         "/samples" : {
             "get" : {
-                "tags" : [
-                    "Samples"
-                ],
+                "tags" : [ "Samples" ],
                 "summary" : "Get a filtered list of Sample",
                 "description" : "Get a list of Sample",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmDbId",
-                        "in" : "query",
-                        "description" : "List of IDs which uniquely identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmName",
-                        "in" : "query",
-                        "description" : "List of human readable names to identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationUnitDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies an `ObservationUnit`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "plateDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a `Plate` of `Samples`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "plateName",
-                        "in" : "query",
-                        "description" : "The human readable name of a `Plate` of `Samples`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "sampleDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a `Sample`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "sampleName",
-                        "in" : "query",
-                        "description" : "The human readable name of the `Sample`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "sampleGroupDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier for a group of related `Samples`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a `Germplasm`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "germplasmDbId",
+                    "in" : "query",
+                    "description" : "List of IDs which uniquely identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmName",
+                    "in" : "query",
+                    "description" : "List of human readable names to identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationUnitDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies an `ObservationUnit`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "plateDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a `Plate` of `Samples`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "plateName",
+                    "in" : "query",
+                    "description" : "The human readable name of a `Plate` of `Samples`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "sampleDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a `Sample`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "sampleName",
+                    "in" : "query",
+                    "description" : "The human readable name of the `Sample`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "sampleGroupDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier for a group of related `Samples`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a `Germplasm`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/SampleListResponse"
@@ -1252,16 +1086,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "Samples"
-                ],
+                "tags" : [ "Samples" ],
                 "summary" : "Update the details for an existing Sample",
                 "description" : "Update the details for an existing Sample",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1287,16 +1117,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "Samples"
-                ],
+                "tags" : [ "Samples" ],
                 "summary" : "Create new Sample",
                 "description" : "Add new Sample to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1324,168 +1150,144 @@
         },
         "/variants" : {
             "get" : {
-                "tags" : [
-                    "Variants"
-                ],
+                "tags" : [ "Variants" ],
                 "summary" : "Get a filtered list of Variant",
                 "description" : "Get a list of Variant",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "callSetDbId",
-                        "in" : "query",
-                        "description" : "**Deprecated in v2.1** Parameter unnecessary. Github issue number #474 \n<br/>Only return variant calls which belong to call sets with these IDs. If unspecified, return all variants and no variant call objects.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "end",
-                        "in" : "query",
-                        "description" : "The end of the window (0-based, exclusive) for which overlapping variants should be returned.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "integer",
-                            "format" : "int32"
-                        }
-                    },
-                    {
-                        "name" : "referenceDbId",
-                        "in" : "query",
-                        "description" : "**Deprecated in v2.1** Please use `referenceDbIds`. Github issue number #472\n<br/>Only return variants on this reference.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "referenceDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier representing a genotype `Reference`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "referenceSetDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier representing a genotype `ReferenceSet`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "start",
-                        "in" : "query",
-                        "description" : "The beginning of the window (0-based, inclusive) for which overlapping variants should be returned. Genomic positions are non-negative integers less than reference length. Requests spanning the join of circular genomes are represented as two requests one on each side of the join (position 0).",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "integer",
-                            "format" : "int32"
-                        }
-                    },
-                    {
-                        "name" : "variantDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `Variants`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "variantSetDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `VariantSets`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "callSetDbId",
+                    "in" : "query",
+                    "description" : "**Deprecated in v2.1** Parameter unnecessary. Github issue number #474 \n<br/>Only return variant calls which belong to call sets with these IDs. If unspecified, return all variants and no variant call objects.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "end",
+                    "in" : "query",
+                    "description" : "The end of the window (0-based, exclusive) for which overlapping variants should be returned.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "integer",
+                        "format" : "int32"
+                    }
+                }, {
+                    "name" : "referenceDbId",
+                    "in" : "query",
+                    "description" : "**Deprecated in v2.1** Please use `referenceDbIds`. Github issue number #472\n<br/>Only return variants on this reference.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "referenceDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier representing a genotype `Reference`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "referenceSetDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier representing a genotype `ReferenceSet`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "start",
+                    "in" : "query",
+                    "description" : "The beginning of the window (0-based, inclusive) for which overlapping variants should be returned. Genomic positions are non-negative integers less than reference length. Requests spanning the join of circular genomes are represented as two requests one on each side of the join (position 0).",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "integer",
+                        "format" : "int32"
+                    }
+                }, {
+                    "name" : "variantDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `Variants`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "variantSetDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `VariantSets`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/VariantListResponse"
@@ -1504,139 +1306,118 @@
         },
         "/variantsets" : {
             "get" : {
-                "tags" : [
-                    "VariantSets"
-                ],
+                "tags" : [ "VariantSets" ],
                 "summary" : "Get a filtered list of VariantSet",
                 "description" : "Get a list of VariantSet",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "callSetDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier representing a CallSet",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "variantDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier representing a Variant",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "variantSetDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier representing a VariantSet",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "referenceDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier representing a genotype Reference",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "referenceSetDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier representing a genotype ReferenceSet",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "callSetDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier representing a CallSet",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "variantDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier representing a Variant",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "variantSetDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier representing a VariantSet",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "referenceDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier representing a genotype Reference",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "referenceSetDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier representing a genotype ReferenceSet",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/VariantSetListResponse"
@@ -1655,9 +1436,7 @@
         },
         "/callsets/{callSetDbId}" : {
             "get" : {
-                "tags" : [
-                    "CallSets"
-                ],
+                "tags" : [ "CallSets" ],
                 "summary" : "Get the details of a specific CallSet",
                 "description" : "Get details for a CallSet",
                 "responses" : {
@@ -1678,85 +1457,72 @@
         },
         "/callsets/{callSetDbId}/calls" : {
             "get" : {
-                "tags" : [
-                    "Calls"
-                ],
+                "tags" : [ "Calls" ],
                 "summary" : "Get a filtered list of Call",
                 "description" : "Get a list of Call",
-                "parameters" : [
-                    {
-                        "name" : "callSetDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `CallSets` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "variantDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `Variant` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "variantSetDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `VariantSets` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "expandHomozygote",
-                        "in" : "query",
-                        "description" : "Should homozygotes be expanded (true) or collapsed into a single occurrence (false)",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "boolean"
-                        }
-                    },
-                    {
-                        "name" : "sepPhased",
-                        "in" : "query",
-                        "description" : "The string used as a separator for phased allele calls.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "sepUnphased",
-                        "in" : "query",
-                        "description" : "The string used as a separator for unphased allele calls.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "unknownString",
-                        "in" : "query",
-                        "description" : "The string used as a representation for missing data.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "callSetDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `CallSets` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "variantDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `Variant` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "variantSetDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `VariantSets` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "expandHomozygote",
+                    "in" : "query",
+                    "description" : "Should homozygotes be expanded (true) or collapsed into a single occurrence (false)",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "boolean"
+                    }
+                }, {
+                    "name" : "sepPhased",
+                    "in" : "query",
+                    "description" : "The string used as a separator for phased allele calls.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "sepUnphased",
+                    "in" : "query",
+                    "description" : "The string used as a separator for unphased allele calls.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "unknownString",
+                    "in" : "query",
+                    "description" : "The string used as a representation for missing data.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/CallListResponse"
@@ -1775,9 +1541,7 @@
         },
         "/maps/{mapDbId}" : {
             "get" : {
-                "tags" : [
-                    "GenomeMaps"
-                ],
+                "tags" : [ "GenomeMaps" ],
                 "summary" : "Get the details of a specific GenomeMap",
                 "description" : "Get details for a GenomeMap",
                 "responses" : {
@@ -1798,9 +1562,7 @@
         },
         "/plates/{plateDbId}" : {
             "get" : {
-                "tags" : [
-                    "Plates"
-                ],
+                "tags" : [ "Plates" ],
                 "summary" : "Get the details of a specific Plate",
                 "description" : "Get details for a Plate",
                 "responses" : {
@@ -1821,9 +1583,7 @@
         },
         "/references/{referenceDbId}" : {
             "get" : {
-                "tags" : [
-                    "References"
-                ],
+                "tags" : [ "References" ],
                 "summary" : "Get the details of a specific Reference",
                 "description" : "Get details for a Reference",
                 "responses" : {
@@ -1844,9 +1604,7 @@
         },
         "/referencesets/{referenceSetDbId}" : {
             "get" : {
-                "tags" : [
-                    "ReferenceSets"
-                ],
+                "tags" : [ "ReferenceSets" ],
                 "summary" : "Get the details of a specific ReferenceSet",
                 "description" : "Get details for a ReferenceSet",
                 "responses" : {
@@ -1867,9 +1625,7 @@
         },
         "/samples/{sampleDbId}" : {
             "get" : {
-                "tags" : [
-                    "Samples"
-                ],
+                "tags" : [ "Samples" ],
                 "summary" : "Get the details of a specific Sample",
                 "description" : "Get details for a Sample",
                 "responses" : {
@@ -1890,9 +1646,7 @@
         },
         "/variants/{variantDbId}" : {
             "get" : {
-                "tags" : [
-                    "Variants"
-                ],
+                "tags" : [ "Variants" ],
                 "summary" : "Get the details of a specific Variant",
                 "description" : "Get details for a Variant",
                 "responses" : {
@@ -1913,85 +1667,72 @@
         },
         "/variants/{variantDbId}/calls" : {
             "get" : {
-                "tags" : [
-                    "Calls"
-                ],
+                "tags" : [ "Calls" ],
                 "summary" : "Get a filtered list of Call",
                 "description" : "Get a list of Call",
-                "parameters" : [
-                    {
-                        "name" : "callSetDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `CallSets` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "variantDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `Variant` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "variantSetDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `VariantSets` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "expandHomozygote",
-                        "in" : "query",
-                        "description" : "Should homozygotes be expanded (true) or collapsed into a single occurrence (false)",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "boolean"
-                        }
-                    },
-                    {
-                        "name" : "sepPhased",
-                        "in" : "query",
-                        "description" : "The string used as a separator for phased allele calls.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "sepUnphased",
-                        "in" : "query",
-                        "description" : "The string used as a separator for unphased allele calls.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "unknownString",
-                        "in" : "query",
-                        "description" : "The string used as a representation for missing data.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "callSetDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `CallSets` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "variantDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `Variant` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "variantSetDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `VariantSets` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "expandHomozygote",
+                    "in" : "query",
+                    "description" : "Should homozygotes be expanded (true) or collapsed into a single occurrence (false)",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "boolean"
+                    }
+                }, {
+                    "name" : "sepPhased",
+                    "in" : "query",
+                    "description" : "The string used as a separator for phased allele calls.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "sepUnphased",
+                    "in" : "query",
+                    "description" : "The string used as a separator for unphased allele calls.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "unknownString",
+                    "in" : "query",
+                    "description" : "The string used as a representation for missing data.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/CallListResponse"
@@ -2010,9 +1751,7 @@
         },
         "/variantsets/{variantSetDbId}" : {
             "get" : {
-                "tags" : [
-                    "VariantSets"
-                ],
+                "tags" : [ "VariantSets" ],
                 "summary" : "Get the details of a specific VariantSet",
                 "description" : "Get details for a VariantSet",
                 "responses" : {
@@ -2033,85 +1772,72 @@
         },
         "/variantsets/{variantSetDbId}/calls" : {
             "get" : {
-                "tags" : [
-                    "Calls"
-                ],
+                "tags" : [ "Calls" ],
                 "summary" : "Get a filtered list of Call",
                 "description" : "Get a list of Call",
-                "parameters" : [
-                    {
-                        "name" : "callSetDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `CallSets` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "variantDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `Variant` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "variantSetDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `VariantSets` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "expandHomozygote",
-                        "in" : "query",
-                        "description" : "Should homozygotes be expanded (true) or collapsed into a single occurrence (false)",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "boolean"
-                        }
-                    },
-                    {
-                        "name" : "sepPhased",
-                        "in" : "query",
-                        "description" : "The string used as a separator for phased allele calls.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "sepUnphased",
-                        "in" : "query",
-                        "description" : "The string used as a separator for unphased allele calls.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "unknownString",
-                        "in" : "query",
-                        "description" : "The string used as a representation for missing data.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "callSetDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `CallSets` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "variantDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `Variant` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "variantSetDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `VariantSets` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "expandHomozygote",
+                    "in" : "query",
+                    "description" : "Should homozygotes be expanded (true) or collapsed into a single occurrence (false)",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "boolean"
+                    }
+                }, {
+                    "name" : "sepPhased",
+                    "in" : "query",
+                    "description" : "The string used as a separator for phased allele calls.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "sepUnphased",
+                    "in" : "query",
+                    "description" : "The string used as a separator for unphased allele calls.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "unknownString",
+                    "in" : "query",
+                    "description" : "The string used as a representation for missing data.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/CallListResponse"
@@ -2130,157 +1856,134 @@
         },
         "/variantsets/{variantSetDbId}/callsets" : {
             "get" : {
-                "tags" : [
-                    "CallSets"
-                ],
+                "tags" : [ "CallSets" ],
                 "summary" : "Get a filtered list of CallSet",
                 "description" : "Get a list of CallSet",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmDbId",
-                        "in" : "query",
-                        "description" : "List of IDs which uniquely identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmName",
-                        "in" : "query",
-                        "description" : "List of human readable names to identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "sampleDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `Samples` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "sampleName",
-                        "in" : "query",
-                        "description" : "A list of human readable names associated with `Samples`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "callSetDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `CallSets` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "callSetName",
-                        "in" : "query",
-                        "description" : "A list of human readable names associated with `CallSets`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "variantSetDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `VariantSets` within the given database server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "germplasmDbId",
+                    "in" : "query",
+                    "description" : "List of IDs which uniquely identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmName",
+                    "in" : "query",
+                    "description" : "List of human readable names to identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "sampleDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `Samples` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "sampleName",
+                    "in" : "query",
+                    "description" : "A list of human readable names associated with `Samples`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "callSetDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `CallSets` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "callSetName",
+                    "in" : "query",
+                    "description" : "A list of human readable names associated with `CallSets`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "variantSetDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `VariantSets` within the given database server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/CallSetListResponse"
@@ -2299,168 +2002,144 @@
         },
         "/variantsets/{variantSetDbId}/variants" : {
             "get" : {
-                "tags" : [
-                    "Variants"
-                ],
+                "tags" : [ "Variants" ],
                 "summary" : "Get a filtered list of Variant",
                 "description" : "Get a list of Variant",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "callSetDbId",
-                        "in" : "query",
-                        "description" : "**Deprecated in v2.1** Parameter unnecessary. Github issue number #474 \n<br/>Only return variant calls which belong to call sets with these IDs. If unspecified, return all variants and no variant call objects.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "end",
-                        "in" : "query",
-                        "description" : "The end of the window (0-based, exclusive) for which overlapping variants should be returned.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "integer",
-                            "format" : "int32"
-                        }
-                    },
-                    {
-                        "name" : "referenceDbId",
-                        "in" : "query",
-                        "description" : "**Deprecated in v2.1** Please use `referenceDbIds`. Github issue number #472\n<br/>Only return variants on this reference.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "referenceDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier representing a genotype `Reference`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "referenceSetDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier representing a genotype `ReferenceSet`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "start",
-                        "in" : "query",
-                        "description" : "The beginning of the window (0-based, inclusive) for which overlapping variants should be returned. Genomic positions are non-negative integers less than reference length. Requests spanning the join of circular genomes are represented as two requests one on each side of the join (position 0).",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "integer",
-                            "format" : "int32"
-                        }
-                    },
-                    {
-                        "name" : "variantDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `Variants`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "variantSetDbId",
-                        "in" : "query",
-                        "description" : "A list of IDs which uniquely identify `VariantSets`",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "callSetDbId",
+                    "in" : "query",
+                    "description" : "**Deprecated in v2.1** Parameter unnecessary. Github issue number #474 \n<br/>Only return variant calls which belong to call sets with these IDs. If unspecified, return all variants and no variant call objects.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "end",
+                    "in" : "query",
+                    "description" : "The end of the window (0-based, exclusive) for which overlapping variants should be returned.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "integer",
+                        "format" : "int32"
+                    }
+                }, {
+                    "name" : "referenceDbId",
+                    "in" : "query",
+                    "description" : "**Deprecated in v2.1** Please use `referenceDbIds`. Github issue number #472\n<br/>Only return variants on this reference.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "referenceDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier representing a genotype `Reference`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "referenceSetDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier representing a genotype `ReferenceSet`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "start",
+                    "in" : "query",
+                    "description" : "The beginning of the window (0-based, inclusive) for which overlapping variants should be returned. Genomic positions are non-negative integers less than reference length. Requests spanning the join of circular genomes are represented as two requests one on each side of the join (position 0).",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "integer",
+                        "format" : "int32"
+                    }
+                }, {
+                    "name" : "variantDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `Variants`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "variantSetDbId",
+                    "in" : "query",
+                    "description" : "A list of IDs which uniquely identify `VariantSets`",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/VariantListResponse"
@@ -2479,9 +2158,7 @@
         },
         "/search/allelematrix" : {
             "post" : {
-                "tags" : [
-                    "AlleleMatrix"
-                ],
+                "tags" : [ "AlleleMatrix" ],
                 "summary" : "Submit a search request for `AlleleMatrix`",
                 "description" : "Submit a search request for `AlleleMatrix`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/alleleMatrix/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2505,9 +2182,7 @@
         },
         "/search/calls" : {
             "post" : {
-                "tags" : [
-                    "Calls"
-                ],
+                "tags" : [ "Calls" ],
                 "summary" : "Submit a search request for `Call`",
                 "description" : "Submit a search request for `Call`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/call/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2531,9 +2206,7 @@
         },
         "/search/callsets" : {
             "post" : {
-                "tags" : [
-                    "CallSets"
-                ],
+                "tags" : [ "CallSets" ],
                 "summary" : "Submit a search request for `CallSet`",
                 "description" : "Submit a search request for `CallSet`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/callSet/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2557,9 +2230,7 @@
         },
         "/search/markerpositions" : {
             "post" : {
-                "tags" : [
-                    "MarkerPositions"
-                ],
+                "tags" : [ "MarkerPositions" ],
                 "summary" : "Submit a search request for `MarkerPosition`",
                 "description" : "Submit a search request for `MarkerPosition`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/markerPosition/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2583,9 +2254,7 @@
         },
         "/search/plates" : {
             "post" : {
-                "tags" : [
-                    "Plates"
-                ],
+                "tags" : [ "Plates" ],
                 "summary" : "Submit a search request for `Plate`",
                 "description" : "Submit a search request for `Plate`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/plate/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2609,9 +2278,7 @@
         },
         "/search/references" : {
             "post" : {
-                "tags" : [
-                    "References"
-                ],
+                "tags" : [ "References" ],
                 "summary" : "Submit a search request for `Reference`",
                 "description" : "Submit a search request for `Reference`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/reference/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2635,9 +2302,7 @@
         },
         "/search/referencesets" : {
             "post" : {
-                "tags" : [
-                    "ReferenceSets"
-                ],
+                "tags" : [ "ReferenceSets" ],
                 "summary" : "Submit a search request for `ReferenceSet`",
                 "description" : "Submit a search request for `ReferenceSet`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/referenceSet/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2661,9 +2326,7 @@
         },
         "/search/samples" : {
             "post" : {
-                "tags" : [
-                    "Samples"
-                ],
+                "tags" : [ "Samples" ],
                 "summary" : "Submit a search request for `Sample`",
                 "description" : "Submit a search request for `Sample`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/sample/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2687,9 +2350,7 @@
         },
         "/search/variants" : {
             "post" : {
-                "tags" : [
-                    "Variants"
-                ],
+                "tags" : [ "Variants" ],
                 "summary" : "Submit a search request for `Variant`",
                 "description" : "Submit a search request for `Variant`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/variant/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2713,9 +2374,7 @@
         },
         "/search/variantsets" : {
             "post" : {
-                "tags" : [
-                    "VariantSets"
-                ],
+                "tags" : [ "VariantSets" ],
                 "summary" : "Submit a search request for `VariantSet`",
                 "description" : "Submit a search request for `VariantSet`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/variantSet/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2739,9 +2398,7 @@
         },
         "/search/allelematrix/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "AlleleMatrix"
-                ],
+                "tags" : [ "AlleleMatrix" ],
                 "summary" : "Submit a search request for `AlleleMatrix`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/alleleMatrix/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `AlleleMatrix` search request <br/>\nClients should submit a search request using the corresponding `POST /search/alleleMatrix` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2762,9 +2419,7 @@
         },
         "/search/calls/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "Calls"
-                ],
+                "tags" : [ "Calls" ],
                 "summary" : "Submit a search request for `Call`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/call/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `Call` search request <br/>\nClients should submit a search request using the corresponding `POST /search/call` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2785,9 +2440,7 @@
         },
         "/search/callsets/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "CallSets"
-                ],
+                "tags" : [ "CallSets" ],
                 "summary" : "Submit a search request for `CallSet`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/callSet/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `CallSet` search request <br/>\nClients should submit a search request using the corresponding `POST /search/callSet` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2808,9 +2461,7 @@
         },
         "/search/markerpositions/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "MarkerPositions"
-                ],
+                "tags" : [ "MarkerPositions" ],
                 "summary" : "Submit a search request for `MarkerPosition`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/markerPosition/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `MarkerPosition` search request <br/>\nClients should submit a search request using the corresponding `POST /search/markerPosition` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2831,9 +2482,7 @@
         },
         "/search/plates/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "Plates"
-                ],
+                "tags" : [ "Plates" ],
                 "summary" : "Submit a search request for `Plate`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/plate/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `Plate` search request <br/>\nClients should submit a search request using the corresponding `POST /search/plate` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2854,9 +2503,7 @@
         },
         "/search/references/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "References"
-                ],
+                "tags" : [ "References" ],
                 "summary" : "Submit a search request for `Reference`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/reference/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `Reference` search request <br/>\nClients should submit a search request using the corresponding `POST /search/reference` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2877,9 +2524,7 @@
         },
         "/search/referencesets/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "ReferenceSets"
-                ],
+                "tags" : [ "ReferenceSets" ],
                 "summary" : "Submit a search request for `ReferenceSet`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/referenceSet/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `ReferenceSet` search request <br/>\nClients should submit a search request using the corresponding `POST /search/referenceSet` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2900,9 +2545,7 @@
         },
         "/search/samples/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "Samples"
-                ],
+                "tags" : [ "Samples" ],
                 "summary" : "Submit a search request for `Sample`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/sample/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `Sample` search request <br/>\nClients should submit a search request using the corresponding `POST /search/sample` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2923,9 +2566,7 @@
         },
         "/search/variants/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "Variants"
-                ],
+                "tags" : [ "Variants" ],
                 "summary" : "Submit a search request for `Variant`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/variant/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `Variant` search request <br/>\nClients should submit a search request using the corresponding `POST /search/variant` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2946,9 +2587,7 @@
         },
         "/search/variantsets/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "VariantSets"
-                ],
+                "tags" : [ "VariantSets" ],
                 "summary" : "Submit a search request for `VariantSet`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/variantSet/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `VariantSet` search request <br/>\nClients should submit a search request using the corresponding `POST /search/variantSet` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2980,10 +2619,7 @@
                 "description" : "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification."
             },
             "AlleleMatrix" : {
-                "required" : [
-                    "callSetDbIds",
-                    "variantSetDbIds"
-                ],
+                "required" : [ "callSetDbIds", "variantSetDbIds" ],
                 "type" : "object",
                 "properties" : {
                     "callSetDbIds" : {
@@ -3039,12 +2675,7 @@
                 }
             },
             "Attribute" : {
-                "required" : [
-                    "attributeName",
-                    "method",
-                    "scale",
-                    "trait"
-                ],
+                "required" : [ "attributeName", "method", "scale", "trait" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3125,11 +2756,7 @@
                 }
             },
             "Call" : {
-                "required" : [
-                    "callSetDbId",
-                    "variantDbId",
-                    "variantSetDbId"
-                ],
+                "required" : [ "callSetDbId", "variantDbId", "variantSetDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3176,9 +2803,7 @@
                 }
             },
             "CallSet" : {
-                "required" : [
-                    "callSetDbId"
-                ],
+                "required" : [ "callSetDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3227,9 +2852,7 @@
                 "properties" : { }
             },
             "Contact" : {
-                "required" : [
-                    "contactDbId"
-                ],
+                "required" : [ "contactDbId" ],
                 "type" : "object",
                 "properties" : {
                     "contactDbId" : {
@@ -3254,20 +2877,13 @@
             },
             "ContentTypes" : {
                 "type" : "string",
-                "enum" : [
-                    "application/json",
-                    "text/csv",
-                    "text/tsv",
-                    "application/flapjack"
-                ]
+                "enum" : [ "application/json", "text/csv", "text/tsv", "application/flapjack" ]
             },
             "Context" : {
                 "title" : "context",
                 "type" : "array",
                 "description" : "The JSON-LD Context is used to provide JSON-LD definitions to each field in a JSON object. By providing an array of context file urls, a BrAPI response object becomes JSON-LD compatible.  \n\nFor more information, see https://w3c.github.io/json-ld-syntax/#the-context",
-                "example" : [
-                    "https://brapi.org/jsonld/context/metadata.jsonld"
-                ],
+                "example" : [ "https://brapi.org/jsonld/context/metadata.jsonld" ],
                 "items" : {
                     "type" : "string",
                     "format" : "uri"
@@ -3285,12 +2901,7 @@
                     "parentType" : {
                         "type" : "string",
                         "description" : "The type of parent ex. 'MALE', 'FEMALE', 'SELF', 'POPULATION', etc.",
-                        "enum" : [
-                            "MALE",
-                            "FEMALE",
-                            "SELF",
-                            "POPULATION"
-                        ]
+                        "enum" : [ "MALE", "FEMALE", "SELF", "POPULATION" ]
                     }
                 }
             },
@@ -3306,11 +2917,7 @@
                 }
             },
             "GenomeMap" : {
-                "required" : [
-                    "commonCropName",
-                    "mapDbId",
-                    "type"
-                ],
+                "required" : [ "commonCropName", "mapDbId", "type" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3369,52 +2976,43 @@
                 "description" : "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.\n\nCopied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
             },
             "GeoJSONGeometry" : {
-                "oneOf" : [
-                    {
-                        "required" : [
-                            "coordinateDbIds",
-                            "type"
-                        ],
-                        "type" : "object",
-                        "properties" : {
-                            "coordinates" : {
-                                "type" : "array",
-                                "items" : {
-                                    "type" : "number"
-                                }
-                            },
-                            "type" : {
-                                "type" : "string"
+                "oneOf" : [ {
+                    "required" : [ "coordinateDbIds", "type" ],
+                    "type" : "object",
+                    "properties" : {
+                        "coordinates" : {
+                            "type" : "array",
+                            "items" : {
+                                "type" : "number"
                             }
                         },
-                        "description" : "Copied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
+                        "type" : {
+                            "type" : "string"
+                        }
                     },
-                    {
-                        "required" : [
-                            "coordinateDbIds",
-                            "type"
-                        ],
-                        "type" : "object",
-                        "properties" : {
-                            "coordinates" : {
+                    "description" : "Copied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
+                }, {
+                    "required" : [ "coordinateDbIds", "type" ],
+                    "type" : "object",
+                    "properties" : {
+                        "coordinates" : {
+                            "type" : "array",
+                            "items" : {
                                 "type" : "array",
                                 "items" : {
                                     "type" : "array",
                                     "items" : {
-                                        "type" : "array",
-                                        "items" : {
-                                            "type" : "number"
-                                        }
+                                        "type" : "number"
                                     }
                                 }
-                            },
-                            "type" : {
-                                "type" : "string"
                             }
                         },
-                        "description" : "An array of Linear Rings. Each Linear Ring is an array of Points. \n\nA Point is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
-                    }
-                ]
+                        "type" : {
+                            "type" : "string"
+                        }
+                    },
+                    "description" : "An array of Linear Rings. Each Linear Ring is an array of Points. \n\nA Point is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
+                } ]
             },
             "GeoJSONSearchArea" : {
                 "type" : "object",
@@ -3428,12 +3026,7 @@
                 }
             },
             "Germplasm" : {
-                "required" : [
-                    "commonCropName",
-                    "germplasmDbId",
-                    "germplasmName",
-                    "germplasmPUI"
-                ],
+                "required" : [ "commonCropName", "germplasmDbId", "germplasmName", "germplasmPUI" ],
                 "type" : "object",
                 "properties" : {
                     "accessionNumber" : {
@@ -3448,29 +3041,7 @@
                     "biologicalStatusOfAccessionCode" : {
                         "type" : "string",
                         "description" : "MCPD (v2.1) (SAMPSTAT) 19. The coding scheme proposed can be used at 3 different levels of detail: either by using the general codes such as 100, 200, 300, 400, or by using the more specific codes such as 110, 120, etc. \n\n100) Wild \n110) Natural \n120) Semi-natural/wild \n130) Semi-natural/sown \n200) Weedy \n300) Traditional cultivar/landrace \n400) Breeding/research material \n410) Breeders line \n411) Synthetic population \n412) Hybrid \n413) Founder stock/base population \n414) Inbred line (parent of hybrid cultivar) \n415) Segregating population \n416) Clonal selection \n420) Genetic stock \n421) Mutant (e.g. induced/insertion mutants, tilling populations) \n422) Cytogenetic stocks (e.g. chromosome addition/substitution, aneuploids,  amphiploids) \n423) Other genetic stocks (e.g. mapping populations) \n500) Advanced or improved cultivar (conventional breeding methods) \n600) GMO (by genetic engineering) \n999) Other (Elaborate in REMARKS field)",
-                        "enum" : [
-                            "100",
-                            "110",
-                            "120",
-                            "130",
-                            "200",
-                            "300",
-                            "400",
-                            "410",
-                            "411",
-                            "412",
-                            "413",
-                            "414",
-                            "415",
-                            "416",
-                            "420",
-                            "421",
-                            "422",
-                            "423",
-                            "500",
-                            "600",
-                            "999"
-                        ]
+                        "enum" : [ "100", "110", "120", "130", "200", "300", "400", "410", "411", "412", "413", "414", "415", "416", "420", "421", "422", "423", "500", "600", "999" ]
                     },
                     "biologicalStatusOfAccessionDescription" : {
                         "type" : "string"
@@ -3552,18 +3123,7 @@
             "ListType" : {
                 "type" : "string",
                 "description" : "The type of objects that are referenced in a List",
-                "enum" : [
-                    "germplasm",
-                    "markers",
-                    "variants",
-                    "programs",
-                    "trials",
-                    "studies",
-                    "observationUnits",
-                    "observations",
-                    "observationVariables",
-                    "samples"
-                ]
+                "enum" : [ "germplasm", "markers", "variants", "programs", "trials", "studies", "observationUnits", "observations", "observationVariables", "samples" ]
             },
             "MarkerPosition" : {
                 "type" : "object",
@@ -3606,9 +3166,7 @@
                 }
             },
             "Method" : {
-                "required" : [
-                    "methodName"
-                ],
+                "required" : [ "methodName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3641,9 +3199,7 @@
                 }
             },
             "ObservationUnit" : {
-                "required" : [
-                    "observationUnitDbId"
-                ],
+                "required" : [ "observationUnitDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3685,11 +3241,7 @@
                             "entryType" : {
                                 "type" : "string",
                                 "description" : "The type of entry for this observation unit. ex. \"CHECK\", \"TEST\", \"FILLER\"",
-                                "enum" : [
-                                    "CHECK",
-                                    "TEST",
-                                    "FILLER"
-                                ]
+                                "enum" : [ "CHECK", "TEST", "FILLER" ]
                             },
                             "geoCoordinates" : {
                                 "type" : "object",
@@ -3718,16 +3270,7 @@
                             "positionCoordinateXType" : {
                                 "type" : "string",
                                 "description" : "The type of positional coordinate used. Must be one of the following values \n\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nPLANTED_ROW - The physical planted row number \n\nPLANTED_INDIVIDUAL - The physical counted number, could be independent or within a planted row \n\nGRID_ROW - The row index number of a square grid overlay \n\nGRID_COL - The column index number of a square grid overlay \n\nMEASURED_ROW - The distance in meters from a defined 0-th row \n\nMEASURED_COL - The distance in meters from a defined 0-th column ",
-                                "enum" : [
-                                    "LONGITUDE",
-                                    "LATITUDE",
-                                    "PLANTED_ROW",
-                                    "PLANTED_INDIVIDUAL",
-                                    "GRID_ROW",
-                                    "GRID_COL",
-                                    "MEASURED_ROW",
-                                    "MEASURED_COL"
-                                ]
+                                "enum" : [ "LONGITUDE", "LATITUDE", "PLANTED_ROW", "PLANTED_INDIVIDUAL", "GRID_ROW", "GRID_COL", "MEASURED_ROW", "MEASURED_COL" ]
                             },
                             "positionCoordinateY" : {
                                 "type" : "string"
@@ -3735,16 +3278,7 @@
                             "positionCoordinateYType" : {
                                 "type" : "string",
                                 "description" : "The type of positional coordinate used. Must be one of the following values \n\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nPLANTED_ROW - The physical planted row number  \n\nPLANTED_INDIVIDUAL - The physical counted number, could be independent or within a planted row \n\nGRID_ROW - The row index number of a square grid overlay \n\nGRID_COL - The column index number of a square grid overlay \n\nMEASURED_ROW - The distance in meters from a defined 0-th row \n\nMEASURED_COL - The distance in meters from a defined 0-th column ",
-                                "enum" : [
-                                    "LONGITUDE",
-                                    "LATITUDE",
-                                    "PLANTED_ROW",
-                                    "PLANTED_INDIVIDUAL",
-                                    "GRID_ROW",
-                                    "GRID_COL",
-                                    "MEASURED_ROW",
-                                    "MEASURED_COL"
-                                ]
+                                "enum" : [ "LONGITUDE", "LATITUDE", "PLANTED_ROW", "PLANTED_INDIVIDUAL", "GRID_ROW", "GRID_COL", "MEASURED_ROW", "MEASURED_COL" ]
                             }
                         },
                         "description" : "All positional and layout information related to this Observation Unit \n\nMIAPPE V1.1 (DM-73) Spatial distribution - Type and value of a spatial coordinate (georeference or relative) \nor level of observation (plot 45, subblock 7, block 2) provided as a key-value pair of the form type:value. \nLevels of observation must be consistent with those listed in the Study section."
@@ -3782,10 +3316,7 @@
                 }
             },
             "Ontology" : {
-                "required" : [
-                    "ontologyDbId",
-                    "ontologyName"
-                ],
+                "required" : [ "ontologyDbId", "ontologyName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3818,9 +3349,7 @@
                 }
             },
             "OntologyReference" : {
-                "required" : [
-                    "ontology"
-                ],
+                "required" : [ "ontology" ],
                 "type" : "object",
                 "properties" : {
                     "documentationLinks" : {
@@ -3833,11 +3362,7 @@
                                 },
                                 "type" : {
                                     "type" : "string",
-                                    "enum" : [
-                                        "OBO",
-                                        "RDF",
-                                        "WEBPAGE"
-                                    ]
+                                    "enum" : [ "OBO", "RDF", "WEBPAGE" ]
                                 }
                             }
                         }
@@ -3851,11 +3376,7 @@
                 }
             },
             "PedigreeNode" : {
-                "required" : [
-                    "germplasmDbId",
-                    "germplasmName",
-                    "germplasmPUI"
-                ],
+                "required" : [ "germplasmDbId", "germplasmName", "germplasmPUI" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3904,10 +3425,7 @@
                 }
             },
             "Plate" : {
-                "required" : [
-                    "plateDbId",
-                    "plateName"
-                ],
+                "required" : [ "plateDbId", "plateName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3919,10 +3437,7 @@
                     "plateFormat" : {
                         "type" : "string",
                         "description" : "Enum for plate formats, usually \"PLATE_96\" for a 96 well plate or \"TUBES\" for plateless format",
-                        "enum" : [
-                            "PLATE_96",
-                            "TUBES"
-                        ]
+                        "enum" : [ "PLATE_96", "TUBES" ]
                     },
                     "plateName" : {
                         "type" : "string"
@@ -3936,12 +3451,7 @@
                     "sampleType" : {
                         "type" : "string",
                         "description" : "The type of samples taken. ex. 'DNA', 'RNA', 'Tissue', etc",
-                        "enum" : [
-                            "DNA",
-                            "RNA",
-                            "TISSUE",
-                            "MIXED"
-                        ]
+                        "enum" : [ "DNA", "RNA", "TISSUE", "MIXED" ]
                     },
                     "studyDbId" : {
                         "type" : "string"
@@ -3964,10 +3474,7 @@
                 }
             },
             "PlateNewRequest" : {
-                "required" : [
-                    "plateDbId",
-                    "plateName"
-                ],
+                "required" : [ "plateDbId", "plateName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3982,10 +3489,7 @@
                     "plateFormat" : {
                         "type" : "string",
                         "description" : "Enum for plate formats, usually \"PLATE_96\" for a 96 well plate or \"TUBES\" for plateless format",
-                        "enum" : [
-                            "PLATE_96",
-                            "TUBES"
-                        ]
+                        "enum" : [ "PLATE_96", "TUBES" ]
                     },
                     "plateName" : {
                         "type" : "string"
@@ -3999,12 +3503,7 @@
                     "sampleType" : {
                         "type" : "string",
                         "description" : "The type of samples taken. ex. 'DNA', 'RNA', 'Tissue', etc",
-                        "enum" : [
-                            "DNA",
-                            "RNA",
-                            "TISSUE",
-                            "MIXED"
-                        ]
+                        "enum" : [ "DNA", "RNA", "TISSUE", "MIXED" ]
                     },
                     "studyDbId" : {
                         "type" : "string"
@@ -4031,10 +3530,7 @@
                 "properties" : { }
             },
             "Reference" : {
-                "required" : [
-                    "referenceDbId",
-                    "referenceName"
-                ],
+                "required" : [ "referenceDbId", "referenceName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -4108,10 +3604,7 @@
                 }
             },
             "ReferenceSet" : {
-                "required" : [
-                    "referenceSetDbId",
-                    "referenceSetName"
-                ],
+                "required" : [ "referenceSetDbId", "referenceSetName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -4171,11 +3664,7 @@
                 }
             },
             "ReferenceSetNewRequest" : {
-                "required" : [
-                    "referenceSetDbId",
-                    "referenceSetDbId",
-                    "referenceSetName"
-                ],
+                "required" : [ "referenceSetDbId", "referenceSetDbId", "referenceSetName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -4242,10 +3731,7 @@
                 "properties" : { }
             },
             "Sample" : {
-                "required" : [
-                    "sampleDbId",
-                    "sampleName"
-                ],
+                "required" : [ "sampleDbId", "sampleName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -4345,10 +3831,7 @@
                 }
             },
             "SampleNewRequest" : {
-                "required" : [
-                    "sampleDbId",
-                    "sampleName"
-                ],
+                "required" : [ "sampleDbId", "sampleName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -4455,10 +3938,7 @@
                 "properties" : { }
             },
             "Scale" : {
-                "required" : [
-                    "scaleDbId",
-                    "scaleName"
-                ],
+                "required" : [ "scaleDbId", "scaleName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -4467,15 +3947,7 @@
                     "dataType" : {
                         "type" : "string",
                         "description" : "<p>Class of the scale, entries can be</p>\n<p>\"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal scale that combines the expressions of the different traits composing the complex trait. For example a severity trait might be expressed by a 2 digit and 2 character code. The first 2 digits are the percentage of the plant covered by a fungus and the 2 characters refer to the delay in development, e.g. \"75VD\" means \"75 %\" of the plant is infected and the plant is very delayed.</p>\n<p>\"Date\" - The date class is for events expressed in a time format, See ISO 8601</p>\n<p>\"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months</p>\n<p>\"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories</p>\n<p>\"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectare, branches</p>\n<p>\"Ordinal\" - Ordinal scales are scales composed of ordered categories</p>\n<p>\"Text\" - A free text is used to express the trait.</p>",
-                        "enum" : [
-                            "Code",
-                            "Date",
-                            "Duration",
-                            "Nominal",
-                            "Numerical",
-                            "Ordinal",
-                            "Text"
-                        ]
+                        "enum" : [ "Code", "Date", "Duration", "Nominal", "Numerical", "Ordinal", "Text" ]
                     },
                     "decimalPlaces" : {
                         "type" : "integer",
@@ -4524,9 +3996,7 @@
                 }
             },
             "Trait" : {
-                "required" : [
-                    "traitName"
-                ],
+                "required" : [ "traitName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -4573,22 +4043,10 @@
             "TraitDataType" : {
                 "type" : "string",
                 "description" : "<p>Class of the scale, entries can be</p>\n<p>\"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal scale that combines the expressions of the different traits composing the complex trait. For example a severity trait might be expressed by a 2 digit and 2 character code. The first 2 digits are the percentage of the plant covered by a fungus and the 2 characters refer to the delay in development, e.g. \"75VD\" means \"75 %\" of the plant is infected and the plant is very delayed.</p>\n<p>\"Date\" - The date class is for events expressed in a time format, See ISO 8601</p>\n<p>\"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months</p>\n<p>\"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories</p>\n<p>\"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectare, branches</p>\n<p>\"Ordinal\" - Ordinal scales are scales composed of ordered categories</p>\n<p>\"Text\" - A free text is used to express the trait.</p>",
-                "enum" : [
-                    "Code",
-                    "Date",
-                    "Duration",
-                    "Nominal",
-                    "Numerical",
-                    "Ordinal",
-                    "Text"
-                ]
+                "enum" : [ "Code", "Date", "Duration", "Nominal", "Numerical", "Ordinal", "Text" ]
             },
             "Variable" : {
-                "required" : [
-                    "method",
-                    "scale",
-                    "trait"
-                ],
+                "required" : [ "method", "scale", "trait" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -4654,9 +4112,7 @@
                 }
             },
             "Variant" : {
-                "required" : [
-                    "variantDbId"
-                ],
+                "required" : [ "variantDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -4732,9 +4188,7 @@
                 }
             },
             "VariantSet" : {
-                "required" : [
-                    "variantSetDbId"
-                ],
+                "required" : [ "variantSetDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -4782,10 +4236,7 @@
                 "properties" : { }
             },
             "basePagination" : {
-                "required" : [
-                    "currentPage",
-                    "pageSize"
-                ],
+                "required" : [ "currentPage", "pageSize" ],
                 "type" : "object",
                 "properties" : {
                     "currentPage" : {
@@ -4814,9 +4265,7 @@
                 "description" : "The pagination object is applicable only when the payload contains a \"data\" key. It describes the pagination of the data contained in the \"data\" array, as a way to identify which subset of data is being returned. \n<br> Pages are zero indexed, so the first page will be page 0 (zero)."
             },
             "dataFile" : {
-                "required" : [
-                    "fileURL"
-                ],
+                "required" : [ "fileURL" ],
                 "type" : "object",
                 "properties" : {
                     "fileURL" : {
@@ -4854,19 +4303,16 @@
                 "description" : "A dataFile contains a URL and the relevant file metadata to represent a file"
             },
             "metadata" : {
-                "allOf" : [
-                    {
-                        "$ref" : "#/components/schemas/metadataBase"
-                    },
-                    {
-                        "type" : "object",
-                        "properties" : {
-                            "pagination" : {
-                                "$ref" : "#/components/schemas/basePagination"
-                            }
+                "allOf" : [ {
+                    "$ref" : "#/components/schemas/metadataBase"
+                }, {
+                    "type" : "object",
+                    "properties" : {
+                        "pagination" : {
+                            "$ref" : "#/components/schemas/basePagination"
                         }
                     }
-                ]
+                } ]
             },
             "metadataBase" : {
                 "type" : "object",
@@ -4890,25 +4336,19 @@
                 "description" : "An object in the BrAPI standard response model that describes some information about the service call being performed. This includes supplementary data, status log messages, and pagination information."
             },
             "metadataTokenPagination" : {
-                "allOf" : [
-                    {
-                        "$ref" : "#/components/schemas/metadataBase"
-                    },
-                    {
-                        "type" : "object",
-                        "properties" : {
-                            "pagination" : {
-                                "$ref" : "#/components/schemas/tokenPagination"
-                            }
+                "allOf" : [ {
+                    "$ref" : "#/components/schemas/metadataBase"
+                }, {
+                    "type" : "object",
+                    "properties" : {
+                        "pagination" : {
+                            "$ref" : "#/components/schemas/tokenPagination"
                         }
                     }
-                ]
+                } ]
             },
             "status" : {
-                "required" : [
-                    "message",
-                    "messageType"
-                ],
+                "required" : [ "message", "messageType" ],
                 "type" : "object",
                 "properties" : {
                     "message" : {
@@ -4920,94 +4360,55 @@
                         "type" : "string",
                         "description" : "The logging level for the attached message",
                         "example" : "INFO",
-                        "enum" : [
-                            "DEBUG",
-                            "ERROR",
-                            "WARNING",
-                            "INFO"
-                        ]
+                        "enum" : [ "DEBUG", "ERROR", "WARNING", "INFO" ]
                     }
                 },
                 "description" : "An array of status messages to convey technical logging information from the server to the client."
             },
             "tokenPagination" : {
-                "allOf" : [
-                    {
-                        "$ref" : "#/components/schemas/basePagination"
-                    },
-                    {
-                        "required" : [
-                            "nextPageToken"
-                        ],
-                        "type" : "object",
-                        "properties" : {
-                            "nextPageToken" : {
-                                "type" : "string",
-                                "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the next page of data.",
-                                "example" : "cb668f63",
-                                "deprecated" : true
-                            },
-                            "currentPageToken" : {
-                                "type" : "string",
-                                "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the current page of data.",
-                                "example" : "48bc6ac1",
-                                "deprecated" : true
-                            },
-                            "prevPageToken" : {
-                                "type" : "string",
-                                "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the previous page of data.",
-                                "example" : "9659857e",
-                                "deprecated" : true
-                            }
+                "allOf" : [ {
+                    "$ref" : "#/components/schemas/basePagination"
+                }, {
+                    "required" : [ "nextPageToken" ],
+                    "type" : "object",
+                    "properties" : {
+                        "nextPageToken" : {
+                            "type" : "string",
+                            "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the next page of data.",
+                            "example" : "cb668f63",
+                            "deprecated" : true
                         },
-                        "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The pagination object is applicable only when the payload contains a \"data\" key. It describes the pagination of the data contained in the \"data\" array, as a way to identify which subset of data is being returned. \n<br>Tokenized pages are for large data sets which can not be efficiently broken into indexed pages. Use the nextPageToken and prevPageToken to construct an additional query and move to the next or previous page respectively.  ",
-                        "example" : {
-                            "currentPage" : 0,
-                            "pageSize" : 1000,
-                            "totalCount" : 10,
-                            "totalPages" : 1
+                        "currentPageToken" : {
+                            "type" : "string",
+                            "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the current page of data.",
+                            "example" : "48bc6ac1",
+                            "deprecated" : true
+                        },
+                        "prevPageToken" : {
+                            "type" : "string",
+                            "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the previous page of data.",
+                            "example" : "9659857e",
+                            "deprecated" : true
                         }
+                    },
+                    "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The pagination object is applicable only when the payload contains a \"data\" key. It describes the pagination of the data contained in the \"data\" array, as a way to identify which subset of data is being returned. \n<br>Tokenized pages are for large data sets which can not be efficiently broken into indexed pages. Use the nextPageToken and prevPageToken to construct an additional query and move to the next or previous page respectively.  ",
+                    "example" : {
+                        "currentPage" : 0,
+                        "pageSize" : 1000,
+                        "totalCount" : 10,
+                        "totalPages" : 1
                     }
-                ]
+                } ]
             }
         },
         "responses" : {
-            "ObservationVariableSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ObservationVariableSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/ObservationVariable"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "SeedLotSingleResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "SeedLotSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5030,10 +4431,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "VariantSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5084,10 +4482,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "StudySingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5110,10 +4505,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "MarkerPositionListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5123,9 +4515,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5147,10 +4537,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "TrialListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5160,9 +4547,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5178,42 +4563,13 @@
                     }
                 }
             },
-            "MethodSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "MethodSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Method"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "SeedLotListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "SeedLotListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5223,9 +4579,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5247,10 +4601,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "VariantSetListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5260,9 +4611,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5284,10 +4633,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "SampleSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5310,10 +4656,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "CallSetListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5323,9 +4666,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5347,10 +4688,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "CallSetSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5373,10 +4711,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "VariantSetSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5399,10 +4734,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ReferenceSetSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5419,53 +4751,13 @@
                     }
                 }
             },
-            "ObservationVariableListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ObservationVariableListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/ObservationVariable"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "CrossListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "CrossListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5475,9 +4767,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5493,42 +4783,13 @@
                     }
                 }
             },
-            "ImageSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ImageSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Image"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "PlateListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "PlateListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5538,9 +4799,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5562,10 +4821,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "SeasonListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5575,9 +4831,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5593,53 +4847,13 @@
                     }
                 }
             },
-            "ObservationUnitListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ObservationUnitListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/ObservationUnit"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "ReferenceListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "ReferenceListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5649,9 +4863,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5667,53 +4879,13 @@
                     }
                 }
             },
-            "ObservationListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ObservationListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Observation"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "AlleleMatrixListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "AlleleMatrixListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5723,9 +4895,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5747,10 +4917,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "GenomeMapSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5773,10 +4940,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "PersonListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5786,9 +4950,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5810,10 +4972,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "PlannedCrossListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5823,9 +4982,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5847,10 +5004,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "LocationListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5860,9 +5014,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5889,42 +5041,13 @@
                     }
                 }
             },
-            "OntologySingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "OntologySingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Ontology"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "ProgramListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "ProgramListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5934,9 +5057,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5952,79 +5073,13 @@
                     }
                 }
             },
-            "ObservationUnitSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ObservationUnitSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/ObservationUnit"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ScaleListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ScaleListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Scale"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "ListListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "ListListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6034,9 +5089,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6063,53 +5116,13 @@
                     }
                 }
             },
-            "MethodListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "MethodListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Method"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "CrossingProjectListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "CrossingProjectListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6119,9 +5132,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6143,10 +5154,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "GermplasmAttributeSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6157,32 +5165,6 @@
                                 },
                                 "result" : {
                                     "$ref" : "#/components/schemas/GermplasmAttribute"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "TraitSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "TraitSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Trait"
                                 }
                             }
                         }
@@ -6206,10 +5188,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "GermplasmAttributeListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6219,9 +5198,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6243,10 +5220,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "GermplasmListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6256,9 +5230,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6280,10 +5252,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "CrossingProjectSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6300,90 +5269,13 @@
                     }
                 }
             },
-            "EventListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "EventListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Event"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "TraitListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "TraitListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Trait"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "SampleListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "SampleListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6393,9 +5285,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6417,10 +5307,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ReferenceSetListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6430,9 +5317,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6454,10 +5339,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "TrialSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6480,10 +5362,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "GermplasmSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6506,10 +5385,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "SeasonSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6532,10 +5408,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ReferenceSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6546,43 +5419,6 @@
                                 },
                                 "result" : {
                                     "$ref" : "#/components/schemas/Reference"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "OntologyListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "OntologyListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Ontology"
-                                            }
-                                        }
-                                    }
                                 }
                             }
                         }
@@ -6606,10 +5442,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "StudyListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6619,9 +5452,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6637,42 +5468,13 @@
                     }
                 }
             },
-            "ScaleSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ScaleSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Scale"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "BreedingMethodSingleResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "BreedingMethodSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6695,10 +5497,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "CallListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6708,9 +5507,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6732,10 +5529,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "LocationSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6758,10 +5552,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "PersonSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6778,53 +5569,13 @@
                     }
                 }
             },
-            "ImageListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ImageListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Image"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "VariantListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "VariantListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6834,9 +5585,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6858,10 +5607,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "PlateSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6884,10 +5630,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "GermplasmAttributeValueListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6897,9 +5640,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6921,10 +5662,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "BreedingMethodListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6934,9 +5672,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6958,10 +5694,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "GermplasmAttributeValueSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6984,10 +5717,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "GenomeMapListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6997,9 +5727,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -7021,10 +5749,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "PedigreeNodeListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -7034,9 +5759,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -7052,42 +5775,13 @@
                     }
                 }
             },
-            "ObservationSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ObservationSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Observation"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "ListSingleResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "ListSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -7110,10 +5804,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ProgramSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {

--- a/java/core/src/test/resources/OpenAPIGenerator/BrAPI-Germplasm-Germplasm.json
+++ b/java/core/src/test/resources/OpenAPIGenerator/BrAPI-Germplasm-Germplasm.json
@@ -7,211 +7,182 @@
     "paths" : {
         "/germplasm" : {
             "get" : {
-                "tags" : [
-                    "Germplasm"
-                ],
+                "tags" : [ "Germplasm" ],
                 "summary" : "Get a filtered list of Germplasm",
                 "description" : "Get a list of Germplasm",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmDbId",
-                        "in" : "query",
-                        "description" : "List of IDs which uniquely identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmName",
-                        "in" : "query",
-                        "description" : "List of human readable names to identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmPUI",
-                        "in" : "query",
-                        "description" : "List of Permanent Unique Identifiers to identify germplasm",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "accessionNumber",
-                        "in" : "query",
-                        "description" : "A collection of unique identifiers for materials or germplasm within a genebank\n\nMCPD (v2.1) (ACCENUMB) 2. This is the unique identifier for accessions within a genebank, and is assigned when a sample is entered into the genebank collection (e.g. \"PI 113869\").",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "collection",
-                        "in" : "query",
-                        "description" : "A specific panel/collection/population name this germplasm belongs to.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "familyCode",
-                        "in" : "query",
-                        "description" : "A familyCode representing the family this germplasm belongs to.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "instituteCode",
-                        "in" : "query",
-                        "description" : "The code for the institute that maintains the material. \n<br/> MCPD (v2.1) (INSTCODE) 1. FAO WIEWS code of the institute where the accession is maintained. The codes consist of the 3-letter ISO 3166 country code of the country where the institute is located plus a number (e.g. PER001). The current set of institute codes is available from http://www.fao.org/wiews. For those institutes not yet having an FAO Code, or for those with \"obsolete\" codes, see \"Common formatting rules (v)\".",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "binomialName",
-                        "in" : "query",
-                        "description" : "List of the full binomial name (scientific name) to identify a germplasm",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "genu",
-                        "in" : "query",
-                        "description" : "List of Genus names to identify germplasm",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "specy",
-                        "in" : "query",
-                        "description" : "List of Species names to identify germplasm",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "synonym",
-                        "in" : "query",
-                        "description" : "List of alternative names or IDs used to reference this germplasm",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "parentDbId",
-                        "in" : "query",
-                        "description" : "Search for Germplasm with these parents",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "progenyDbId",
-                        "in" : "query",
-                        "description" : "Search for Germplasm with these children",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "germplasmDbId",
+                    "in" : "query",
+                    "description" : "List of IDs which uniquely identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmName",
+                    "in" : "query",
+                    "description" : "List of human readable names to identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmPUI",
+                    "in" : "query",
+                    "description" : "List of Permanent Unique Identifiers to identify germplasm",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "accessionNumber",
+                    "in" : "query",
+                    "description" : "A collection of unique identifiers for materials or germplasm within a genebank\n\nMCPD (v2.1) (ACCENUMB) 2. This is the unique identifier for accessions within a genebank, and is assigned when a sample is entered into the genebank collection (e.g. \"PI 113869\").",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "collection",
+                    "in" : "query",
+                    "description" : "A specific panel/collection/population name this germplasm belongs to.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "familyCode",
+                    "in" : "query",
+                    "description" : "A familyCode representing the family this germplasm belongs to.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "instituteCode",
+                    "in" : "query",
+                    "description" : "The code for the institute that maintains the material. \n<br/> MCPD (v2.1) (INSTCODE) 1. FAO WIEWS code of the institute where the accession is maintained. The codes consist of the 3-letter ISO 3166 country code of the country where the institute is located plus a number (e.g. PER001). The current set of institute codes is available from http://www.fao.org/wiews. For those institutes not yet having an FAO Code, or for those with \"obsolete\" codes, see \"Common formatting rules (v)\".",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "binomialName",
+                    "in" : "query",
+                    "description" : "List of the full binomial name (scientific name) to identify a germplasm",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "genu",
+                    "in" : "query",
+                    "description" : "List of Genus names to identify germplasm",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "specy",
+                    "in" : "query",
+                    "description" : "List of Species names to identify germplasm",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "synonym",
+                    "in" : "query",
+                    "description" : "List of alternative names or IDs used to reference this germplasm",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "parentDbId",
+                    "in" : "query",
+                    "description" : "Search for Germplasm with these parents",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "progenyDbId",
+                    "in" : "query",
+                    "description" : "Search for Germplasm with these children",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/GermplasmListResponse"
@@ -228,16 +199,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "Germplasm"
-                ],
+                "tags" : [ "Germplasm" ],
                 "summary" : "Create new Germplasm",
                 "description" : "Add new Germplasm to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -265,9 +232,7 @@
         },
         "/germplasm/{germplasmDbId}" : {
             "get" : {
-                "tags" : [
-                    "Germplasm"
-                ],
+                "tags" : [ "Germplasm" ],
                 "summary" : "Get the details of a specific Germplasm",
                 "description" : "Get details for a Germplasm",
                 "responses" : {
@@ -286,16 +251,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "Germplasm"
-                ],
+                "tags" : [ "Germplasm" ],
                 "summary" : "Update the details for an existing Germplasm",
                 "description" : "Update the details for an existing Germplasm",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -323,9 +284,7 @@
         },
         "/search/germplasm" : {
             "post" : {
-                "tags" : [
-                    "Germplasm"
-                ],
+                "tags" : [ "Germplasm" ],
                 "summary" : "Submit a search request for `Germplasm`",
                 "description" : "Submit a search request for `Germplasm`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/germplasm/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -349,9 +308,7 @@
         },
         "/search/germplasm/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "Germplasm"
-                ],
+                "tags" : [ "Germplasm" ],
                 "summary" : "Submit a search request for `Germplasm`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/germplasm/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `Germplasm` search request <br/>\nClients should submit a search request using the corresponding `POST /search/germplasm` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -375,32 +332,20 @@
         "schemas" : {
             "ContentTypes" : {
                 "type" : "string",
-                "enum" : [
-                    "application/json",
-                    "text/csv",
-                    "text/tsv",
-                    "application/flapjack"
-                ]
+                "enum" : [ "application/json", "text/csv", "text/tsv", "application/flapjack" ]
             },
             "Context" : {
                 "title" : "context",
                 "type" : "array",
                 "description" : "The JSON-LD Context is used to provide JSON-LD definitions to each field in a JSON object. By providing an array of context file urls, a BrAPI response object becomes JSON-LD compatible.  \n\nFor more information, see https://w3c.github.io/json-ld-syntax/#the-context",
-                "example" : [
-                    "https://brapi.org/jsonld/context/metadata.jsonld"
-                ],
+                "example" : [ "https://brapi.org/jsonld/context/metadata.jsonld" ],
                 "items" : {
                     "type" : "string",
                     "format" : "uri"
                 }
             },
             "Germplasm" : {
-                "required" : [
-                    "commonCropName",
-                    "germplasmDbId",
-                    "germplasmName",
-                    "germplasmPUI"
-                ],
+                "required" : [ "commonCropName", "germplasmDbId", "germplasmName", "germplasmPUI" ],
                 "type" : "object",
                 "properties" : {
                     "accessionNumber" : {
@@ -415,29 +360,7 @@
                     "biologicalStatusOfAccessionCode" : {
                         "type" : "string",
                         "description" : "MCPD (v2.1) (SAMPSTAT) 19. The coding scheme proposed can be used at 3 different levels of detail: either by using the general codes such as 100, 200, 300, 400, or by using the more specific codes such as 110, 120, etc. \n\n100) Wild \n110) Natural \n120) Semi-natural/wild \n130) Semi-natural/sown \n200) Weedy \n300) Traditional cultivar/landrace \n400) Breeding/research material \n410) Breeders line \n411) Synthetic population \n412) Hybrid \n413) Founder stock/base population \n414) Inbred line (parent of hybrid cultivar) \n415) Segregating population \n416) Clonal selection \n420) Genetic stock \n421) Mutant (e.g. induced/insertion mutants, tilling populations) \n422) Cytogenetic stocks (e.g. chromosome addition/substitution, aneuploids,  amphiploids) \n423) Other genetic stocks (e.g. mapping populations) \n500) Advanced or improved cultivar (conventional breeding methods) \n600) GMO (by genetic engineering) \n999) Other (Elaborate in REMARKS field)",
-                        "enum" : [
-                            "100",
-                            "110",
-                            "120",
-                            "130",
-                            "200",
-                            "300",
-                            "400",
-                            "410",
-                            "411",
-                            "412",
-                            "413",
-                            "414",
-                            "415",
-                            "416",
-                            "420",
-                            "421",
-                            "422",
-                            "423",
-                            "500",
-                            "600",
-                            "999"
-                        ]
+                        "enum" : [ "100", "110", "120", "130", "200", "300", "400", "410", "411", "412", "413", "414", "415", "416", "420", "421", "422", "423", "500", "600", "999" ]
                     },
                     "biologicalStatusOfAccessionDescription" : {
                         "type" : "string"
@@ -514,13 +437,7 @@
                 }
             },
             "GermplasmNewRequest" : {
-                "required" : [
-                    "commonCropName",
-                    "germplasmDbId",
-                    "germplasmDbId",
-                    "germplasmName",
-                    "germplasmPUI"
-                ],
+                "required" : [ "commonCropName", "germplasmDbId", "germplasmDbId", "germplasmName", "germplasmPUI" ],
                 "type" : "object",
                 "properties" : {
                     "accessionNumber" : {
@@ -535,29 +452,7 @@
                     "biologicalStatusOfAccessionCode" : {
                         "type" : "string",
                         "description" : "MCPD (v2.1) (SAMPSTAT) 19. The coding scheme proposed can be used at 3 different levels of detail: either by using the general codes such as 100, 200, 300, 400, or by using the more specific codes such as 110, 120, etc. \n\n100) Wild \n110) Natural \n120) Semi-natural/wild \n130) Semi-natural/sown \n200) Weedy \n300) Traditional cultivar/landrace \n400) Breeding/research material \n410) Breeders line \n411) Synthetic population \n412) Hybrid \n413) Founder stock/base population \n414) Inbred line (parent of hybrid cultivar) \n415) Segregating population \n416) Clonal selection \n420) Genetic stock \n421) Mutant (e.g. induced/insertion mutants, tilling populations) \n422) Cytogenetic stocks (e.g. chromosome addition/substitution, aneuploids,  amphiploids) \n423) Other genetic stocks (e.g. mapping populations) \n500) Advanced or improved cultivar (conventional breeding methods) \n600) GMO (by genetic engineering) \n999) Other (Elaborate in REMARKS field)",
-                        "enum" : [
-                            "100",
-                            "110",
-                            "120",
-                            "130",
-                            "200",
-                            "300",
-                            "400",
-                            "410",
-                            "411",
-                            "412",
-                            "413",
-                            "414",
-                            "415",
-                            "416",
-                            "420",
-                            "421",
-                            "422",
-                            "423",
-                            "500",
-                            "600",
-                            "999"
-                        ]
+                        "enum" : [ "100", "110", "120", "130", "200", "300", "400", "410", "411", "412", "413", "414", "415", "416", "420", "421", "422", "423", "500", "600", "999" ]
                     },
                     "biologicalStatusOfAccessionDescription" : {
                         "type" : "string"
@@ -641,10 +536,7 @@
                 "properties" : { }
             },
             "basePagination" : {
-                "required" : [
-                    "currentPage",
-                    "pageSize"
-                ],
+                "required" : [ "currentPage", "pageSize" ],
                 "type" : "object",
                 "properties" : {
                     "currentPage" : {
@@ -673,9 +565,7 @@
                 "description" : "The pagination object is applicable only when the payload contains a \"data\" key. It describes the pagination of the data contained in the \"data\" array, as a way to identify which subset of data is being returned. \n<br> Pages are zero indexed, so the first page will be page 0 (zero)."
             },
             "dataFile" : {
-                "required" : [
-                    "fileURL"
-                ],
+                "required" : [ "fileURL" ],
                 "type" : "object",
                 "properties" : {
                     "fileURL" : {
@@ -713,19 +603,16 @@
                 "description" : "A dataFile contains a URL and the relevant file metadata to represent a file"
             },
             "metadata" : {
-                "allOf" : [
-                    {
-                        "$ref" : "#/components/schemas/metadataBase"
-                    },
-                    {
-                        "type" : "object",
-                        "properties" : {
-                            "pagination" : {
-                                "$ref" : "#/components/schemas/basePagination"
-                            }
+                "allOf" : [ {
+                    "$ref" : "#/components/schemas/metadataBase"
+                }, {
+                    "type" : "object",
+                    "properties" : {
+                        "pagination" : {
+                            "$ref" : "#/components/schemas/basePagination"
                         }
                     }
-                ]
+                } ]
             },
             "metadataBase" : {
                 "type" : "object",
@@ -749,25 +636,19 @@
                 "description" : "An object in the BrAPI standard response model that describes some information about the service call being performed. This includes supplementary data, status log messages, and pagination information."
             },
             "metadataTokenPagination" : {
-                "allOf" : [
-                    {
-                        "$ref" : "#/components/schemas/metadataBase"
-                    },
-                    {
-                        "type" : "object",
-                        "properties" : {
-                            "pagination" : {
-                                "$ref" : "#/components/schemas/tokenPagination"
-                            }
+                "allOf" : [ {
+                    "$ref" : "#/components/schemas/metadataBase"
+                }, {
+                    "type" : "object",
+                    "properties" : {
+                        "pagination" : {
+                            "$ref" : "#/components/schemas/tokenPagination"
                         }
                     }
-                ]
+                } ]
             },
             "status" : {
-                "required" : [
-                    "message",
-                    "messageType"
-                ],
+                "required" : [ "message", "messageType" ],
                 "type" : "object",
                 "properties" : {
                     "message" : {
@@ -779,55 +660,45 @@
                         "type" : "string",
                         "description" : "The logging level for the attached message",
                         "example" : "INFO",
-                        "enum" : [
-                            "DEBUG",
-                            "ERROR",
-                            "WARNING",
-                            "INFO"
-                        ]
+                        "enum" : [ "DEBUG", "ERROR", "WARNING", "INFO" ]
                     }
                 },
                 "description" : "An array of status messages to convey technical logging information from the server to the client."
             },
             "tokenPagination" : {
-                "allOf" : [
-                    {
-                        "$ref" : "#/components/schemas/basePagination"
-                    },
-                    {
-                        "required" : [
-                            "nextPageToken"
-                        ],
-                        "type" : "object",
-                        "properties" : {
-                            "nextPageToken" : {
-                                "type" : "string",
-                                "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the next page of data.",
-                                "example" : "cb668f63",
-                                "deprecated" : true
-                            },
-                            "currentPageToken" : {
-                                "type" : "string",
-                                "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the current page of data.",
-                                "example" : "48bc6ac1",
-                                "deprecated" : true
-                            },
-                            "prevPageToken" : {
-                                "type" : "string",
-                                "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the previous page of data.",
-                                "example" : "9659857e",
-                                "deprecated" : true
-                            }
+                "allOf" : [ {
+                    "$ref" : "#/components/schemas/basePagination"
+                }, {
+                    "required" : [ "nextPageToken" ],
+                    "type" : "object",
+                    "properties" : {
+                        "nextPageToken" : {
+                            "type" : "string",
+                            "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the next page of data.",
+                            "example" : "cb668f63",
+                            "deprecated" : true
                         },
-                        "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The pagination object is applicable only when the payload contains a \"data\" key. It describes the pagination of the data contained in the \"data\" array, as a way to identify which subset of data is being returned. \n<br>Tokenized pages are for large data sets which can not be efficiently broken into indexed pages. Use the nextPageToken and prevPageToken to construct an additional query and move to the next or previous page respectively.  ",
-                        "example" : {
-                            "currentPage" : 0,
-                            "pageSize" : 1000,
-                            "totalCount" : 10,
-                            "totalPages" : 1
+                        "currentPageToken" : {
+                            "type" : "string",
+                            "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the current page of data.",
+                            "example" : "48bc6ac1",
+                            "deprecated" : true
+                        },
+                        "prevPageToken" : {
+                            "type" : "string",
+                            "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the previous page of data.",
+                            "example" : "9659857e",
+                            "deprecated" : true
                         }
+                    },
+                    "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The pagination object is applicable only when the payload contains a \"data\" key. It describes the pagination of the data contained in the \"data\" array, as a way to identify which subset of data is being returned. \n<br>Tokenized pages are for large data sets which can not be efficiently broken into indexed pages. Use the nextPageToken and prevPageToken to construct an additional query and move to the next or previous page respectively.  ",
+                    "example" : {
+                        "currentPage" : 0,
+                        "pageSize" : 1000,
+                        "totalCount" : 10,
+                        "totalPages" : 1
                     }
-                ]
+                } ]
             }
         },
         "responses" : {
@@ -848,10 +719,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "GermplasmListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -861,9 +729,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -913,10 +779,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "GermplasmSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -927,32 +790,6 @@
                                 },
                                 "result" : {
                                     "$ref" : "#/components/schemas/Germplasm"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "StudySingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "StudySingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Study"
                                 }
                             }
                         }
@@ -978,43 +815,6 @@
                             "type" : "string"
                         },
                         "example" : "ERROR - 2018-10-08T18:15:11Z - The requested object DbId is not found"
-                    }
-                }
-            },
-            "StudyListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "StudyListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Study"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
                     }
                 }
             },

--- a/java/core/src/test/resources/OpenAPIGenerator/BrAPI-Germplasm.json
+++ b/java/core/src/test/resources/OpenAPIGenerator/BrAPI-Germplasm.json
@@ -7,9 +7,7 @@
     "paths" : {
         "/breedingmethods" : {
             "get" : {
-                "tags" : [
-                    "Germplasm"
-                ],
+                "tags" : [ "Germplasm" ],
                 "summary" : "Get a filtered list of BreedingMethod",
                 "description" : "Get a list of BreedingMethod",
                 "parameters" : [ ],
@@ -31,94 +29,78 @@
         },
         "/crosses" : {
             "get" : {
-                "tags" : [
-                    "Crosses"
-                ],
+                "tags" : [ "Crosses" ],
                 "summary" : "Get a filtered list of Cross",
                 "description" : "Get a list of Cross",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "crossingProjectDbId",
-                        "in" : "query",
-                        "description" : "Search for Crossing Projects with this unique id",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "crossingProjectName",
-                        "in" : "query",
-                        "description" : "The human readable name for a crossing project",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "crossDbId",
-                        "in" : "query",
-                        "description" : "Search for Cross with this unique id",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "crossName",
-                        "in" : "query",
-                        "description" : "Search for Cross with this human readable name",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "crossingProjectDbId",
+                    "in" : "query",
+                    "description" : "Search for Crossing Projects with this unique id",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "crossingProjectName",
+                    "in" : "query",
+                    "description" : "The human readable name for a crossing project",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "crossDbId",
+                    "in" : "query",
+                    "description" : "Search for Cross with this unique id",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "crossName",
+                    "in" : "query",
+                    "description" : "Search for Cross with this human readable name",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/CrossListResponse"
@@ -135,16 +117,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "Crosses"
-                ],
+                "tags" : [ "Crosses" ],
                 "summary" : "Update the details for an existing Cross",
                 "description" : "Update the details for an existing Cross",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -170,16 +148,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "Crosses"
-                ],
+                "tags" : [ "Crosses" ],
                 "summary" : "Create new Cross",
                 "description" : "Add new Cross to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -207,85 +181,70 @@
         },
         "/crossingprojects" : {
             "get" : {
-                "tags" : [
-                    "CrossingProjects"
-                ],
+                "tags" : [ "CrossingProjects" ],
                 "summary" : "Get a filtered list of CrossingProject",
                 "description" : "Get a list of CrossingProject",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "crossingProjectDbId",
-                        "in" : "query",
-                        "description" : "Search for Crossing Projects with this unique id",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "crossingProjectName",
-                        "in" : "query",
-                        "description" : "The human readable name for a crossing project",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "includePotentialParent",
-                        "in" : "query",
-                        "description" : "If the parameter 'includePotentialParents' is false, the array 'potentialParents' should be empty, null, or excluded from the response object.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "boolean"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "crossingProjectDbId",
+                    "in" : "query",
+                    "description" : "Search for Crossing Projects with this unique id",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "crossingProjectName",
+                    "in" : "query",
+                    "description" : "The human readable name for a crossing project",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "includePotentialParent",
+                    "in" : "query",
+                    "description" : "If the parameter 'includePotentialParents' is false, the array 'potentialParents' should be empty, null, or excluded from the response object.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "boolean"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/CrossingProjectListResponse"
@@ -302,16 +261,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "CrossingProjects"
-                ],
+                "tags" : [ "CrossingProjects" ],
                 "summary" : "Create new CrossingProject",
                 "description" : "Add new CrossingProject to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -339,211 +294,182 @@
         },
         "/germplasm" : {
             "get" : {
-                "tags" : [
-                    "Germplasm"
-                ],
+                "tags" : [ "Germplasm" ],
                 "summary" : "Get a filtered list of Germplasm",
                 "description" : "Get a list of Germplasm",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmDbId",
-                        "in" : "query",
-                        "description" : "List of IDs which uniquely identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmName",
-                        "in" : "query",
-                        "description" : "List of human readable names to identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmPUI",
-                        "in" : "query",
-                        "description" : "List of Permanent Unique Identifiers to identify germplasm",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "accessionNumber",
-                        "in" : "query",
-                        "description" : "A collection of unique identifiers for materials or germplasm within a genebank\n\nMCPD (v2.1) (ACCENUMB) 2. This is the unique identifier for accessions within a genebank, and is assigned when a sample is entered into the genebank collection (e.g. \"PI 113869\").",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "collection",
-                        "in" : "query",
-                        "description" : "A specific panel/collection/population name this germplasm belongs to.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "familyCode",
-                        "in" : "query",
-                        "description" : "A familyCode representing the family this germplasm belongs to.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "instituteCode",
-                        "in" : "query",
-                        "description" : "The code for the institute that maintains the material. \n<br/> MCPD (v2.1) (INSTCODE) 1. FAO WIEWS code of the institute where the accession is maintained. The codes consist of the 3-letter ISO 3166 country code of the country where the institute is located plus a number (e.g. PER001). The current set of institute codes is available from http://www.fao.org/wiews. For those institutes not yet having an FAO Code, or for those with \"obsolete\" codes, see \"Common formatting rules (v)\".",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "binomialName",
-                        "in" : "query",
-                        "description" : "List of the full binomial name (scientific name) to identify a germplasm",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "genu",
-                        "in" : "query",
-                        "description" : "List of Genus names to identify germplasm",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "specy",
-                        "in" : "query",
-                        "description" : "List of Species names to identify germplasm",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "synonym",
-                        "in" : "query",
-                        "description" : "List of alternative names or IDs used to reference this germplasm",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "parentDbId",
-                        "in" : "query",
-                        "description" : "Search for Germplasm with these parents",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "progenyDbId",
-                        "in" : "query",
-                        "description" : "Search for Germplasm with these children",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "germplasmDbId",
+                    "in" : "query",
+                    "description" : "List of IDs which uniquely identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmName",
+                    "in" : "query",
+                    "description" : "List of human readable names to identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmPUI",
+                    "in" : "query",
+                    "description" : "List of Permanent Unique Identifiers to identify germplasm",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "accessionNumber",
+                    "in" : "query",
+                    "description" : "A collection of unique identifiers for materials or germplasm within a genebank\n\nMCPD (v2.1) (ACCENUMB) 2. This is the unique identifier for accessions within a genebank, and is assigned when a sample is entered into the genebank collection (e.g. \"PI 113869\").",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "collection",
+                    "in" : "query",
+                    "description" : "A specific panel/collection/population name this germplasm belongs to.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "familyCode",
+                    "in" : "query",
+                    "description" : "A familyCode representing the family this germplasm belongs to.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "instituteCode",
+                    "in" : "query",
+                    "description" : "The code for the institute that maintains the material. \n<br/> MCPD (v2.1) (INSTCODE) 1. FAO WIEWS code of the institute where the accession is maintained. The codes consist of the 3-letter ISO 3166 country code of the country where the institute is located plus a number (e.g. PER001). The current set of institute codes is available from http://www.fao.org/wiews. For those institutes not yet having an FAO Code, or for those with \"obsolete\" codes, see \"Common formatting rules (v)\".",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "binomialName",
+                    "in" : "query",
+                    "description" : "List of the full binomial name (scientific name) to identify a germplasm",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "genu",
+                    "in" : "query",
+                    "description" : "List of Genus names to identify germplasm",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "specy",
+                    "in" : "query",
+                    "description" : "List of Species names to identify germplasm",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "synonym",
+                    "in" : "query",
+                    "description" : "List of alternative names or IDs used to reference this germplasm",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "parentDbId",
+                    "in" : "query",
+                    "description" : "Search for Germplasm with these parents",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "progenyDbId",
+                    "in" : "query",
+                    "description" : "Search for Germplasm with these children",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/GermplasmListResponse"
@@ -560,16 +486,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "Germplasm"
-                ],
+                "tags" : [ "Germplasm" ],
                 "summary" : "Create new Germplasm",
                 "description" : "Add new Germplasm to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -597,175 +519,150 @@
         },
         "/attributes" : {
             "get" : {
-                "tags" : [
-                    "GermplasmAttributes"
-                ],
+                "tags" : [ "GermplasmAttributes" ],
                 "summary" : "Get a filtered list of GermplasmAttribute",
                 "description" : "Get a list of GermplasmAttribute",
-                "parameters" : [
-                    {
-                        "name" : "germplasmDbId",
-                        "in" : "query",
-                        "description" : "List of IDs which uniquely identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "methodDbId",
-                        "in" : "query",
-                        "description" : "List of methods to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "methodName",
-                        "in" : "query",
-                        "description" : "Human readable name for the method\n<br/>MIAPPE V1.1 (DM-88) Method  Name of the method of observation",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "methodPUI",
-                        "in" : "query",
-                        "description" : "The Permanent Unique Identifier of a Method, usually in the form of a URI",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "scaleDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier for a Scale",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "scaleName",
-                        "in" : "query",
-                        "description" : "Name of the scale\n<br/>MIAPPE V1.1 (DM-92) Scale Name of the scale associated with the variable",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "scalePUI",
-                        "in" : "query",
-                        "description" : "The Permanent Unique Identifier of a Scale, usually in the form of a URI",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "traitDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier for a Trait",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "traitName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trait\n<br/>MIAPPE V1.1 (DM-86) Trait - Name of the (plant or environmental) trait under observation",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "traitPUI",
-                        "in" : "query",
-                        "description" : "The Permanent Unique Identifier of a Trait, usually in the form of a URI",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "attributeDbId",
-                        "in" : "query",
-                        "description" : "List of Germplasm Attribute IDs to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "attributeName",
-                        "in" : "query",
-                        "description" : "List of human readable Germplasm Attribute names to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "attributePUI",
-                        "in" : "query",
-                        "description" : "The Permanent Unique Identifier of an Attribute, usually in the form of a URI",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "attributeCategory",
-                        "in" : "query",
-                        "description" : "General category for the attribute. very similar to Trait class.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "germplasmDbId",
+                    "in" : "query",
+                    "description" : "List of IDs which uniquely identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "methodDbId",
+                    "in" : "query",
+                    "description" : "List of methods to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "methodName",
+                    "in" : "query",
+                    "description" : "Human readable name for the method\n<br/>MIAPPE V1.1 (DM-88) Method  Name of the method of observation",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "methodPUI",
+                    "in" : "query",
+                    "description" : "The Permanent Unique Identifier of a Method, usually in the form of a URI",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "scaleDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier for a Scale",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "scaleName",
+                    "in" : "query",
+                    "description" : "Name of the scale\n<br/>MIAPPE V1.1 (DM-92) Scale Name of the scale associated with the variable",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "scalePUI",
+                    "in" : "query",
+                    "description" : "The Permanent Unique Identifier of a Scale, usually in the form of a URI",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "traitDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier for a Trait",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "traitName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trait\n<br/>MIAPPE V1.1 (DM-86) Trait - Name of the (plant or environmental) trait under observation",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "traitPUI",
+                    "in" : "query",
+                    "description" : "The Permanent Unique Identifier of a Trait, usually in the form of a URI",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "attributeDbId",
+                    "in" : "query",
+                    "description" : "List of Germplasm Attribute IDs to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "attributeName",
+                    "in" : "query",
+                    "description" : "List of human readable Germplasm Attribute names to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "attributePUI",
+                    "in" : "query",
+                    "description" : "The Permanent Unique Identifier of an Attribute, usually in the form of a URI",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "attributeCategory",
+                    "in" : "query",
+                    "description" : "General category for the attribute. very similar to Trait class.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/GermplasmAttributeListResponse"
@@ -782,16 +679,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "GermplasmAttributes"
-                ],
+                "tags" : [ "GermplasmAttributes" ],
                 "summary" : "Create new GermplasmAttribute",
                 "description" : "Add new GermplasmAttribute to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -819,157 +712,134 @@
         },
         "/attributevalues" : {
             "get" : {
-                "tags" : [
-                    "GermplasmAttributeValues"
-                ],
+                "tags" : [ "GermplasmAttributeValues" ],
                 "summary" : "Get a filtered list of GermplasmAttributeValue",
                 "description" : "Get a list of GermplasmAttributeValue",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmDbId",
-                        "in" : "query",
-                        "description" : "List of IDs which uniquely identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmName",
-                        "in" : "query",
-                        "description" : "List of human readable names to identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "attributeValueDbId",
-                        "in" : "query",
-                        "description" : "List of Germplasm Attribute Value IDs to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "attributeDbId",
-                        "in" : "query",
-                        "description" : "List of Germplasm Attribute IDs to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "attributeName",
-                        "in" : "query",
-                        "description" : "List of human readable Germplasm Attribute names to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "ontologyDbId",
-                        "in" : "query",
-                        "description" : "List of ontology IDs to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "methodDbId",
-                        "in" : "query",
-                        "description" : "List of methods to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "scaleDbId",
-                        "in" : "query",
-                        "description" : "List of scales to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "traitDbId",
-                        "in" : "query",
-                        "description" : "List of trait unique ID to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "traitClass",
-                        "in" : "query",
-                        "description" : "List of trait classes to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "dataType",
-                        "in" : "query",
-                        "description" : "List of scale data types to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "$ref" : "#/components/schemas/TraitDataType"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "germplasmDbId",
+                    "in" : "query",
+                    "description" : "List of IDs which uniquely identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmName",
+                    "in" : "query",
+                    "description" : "List of human readable names to identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "attributeValueDbId",
+                    "in" : "query",
+                    "description" : "List of Germplasm Attribute Value IDs to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "attributeDbId",
+                    "in" : "query",
+                    "description" : "List of Germplasm Attribute IDs to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "attributeName",
+                    "in" : "query",
+                    "description" : "List of human readable Germplasm Attribute names to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "ontologyDbId",
+                    "in" : "query",
+                    "description" : "List of ontology IDs to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "methodDbId",
+                    "in" : "query",
+                    "description" : "List of methods to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "scaleDbId",
+                    "in" : "query",
+                    "description" : "List of scales to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "traitDbId",
+                    "in" : "query",
+                    "description" : "List of trait unique ID to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "traitClass",
+                    "in" : "query",
+                    "description" : "List of trait classes to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "dataType",
+                    "in" : "query",
+                    "description" : "List of scale data types to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "$ref" : "#/components/schemas/TraitDataType"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/GermplasmAttributeValueListResponse"
@@ -986,16 +856,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "GermplasmAttributeValues"
-                ],
+                "tags" : [ "GermplasmAttributeValues" ],
                 "summary" : "Create new GermplasmAttributeValue",
                 "description" : "Add new GermplasmAttributeValue to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1023,249 +889,216 @@
         },
         "/pedigree" : {
             "get" : {
-                "tags" : [
-                    "PedigreeNodes"
-                ],
+                "tags" : [ "PedigreeNodes" ],
                 "summary" : "Get a filtered list of PedigreeNode",
                 "description" : "Get a list of PedigreeNode",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmDbId",
-                        "in" : "query",
-                        "description" : "List of IDs which uniquely identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmName",
-                        "in" : "query",
-                        "description" : "List of human readable names to identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmPUI",
-                        "in" : "query",
-                        "description" : "List of Permanent Unique Identifiers to identify germplasm",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "accessionNumber",
-                        "in" : "query",
-                        "description" : "A collection of unique identifiers for materials or germplasm within a genebank\n\nMCPD (v2.1) (ACCENUMB) 2. This is the unique identifier for accessions within a genebank, and is assigned when a sample is entered into the genebank collection (e.g. \"PI 113869\").",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "collection",
-                        "in" : "query",
-                        "description" : "A specific panel/collection/population name this germplasm belongs to.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "familyCode",
-                        "in" : "query",
-                        "description" : "A familyCode representing the family this germplasm belongs to.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "instituteCode",
-                        "in" : "query",
-                        "description" : "The code for the institute that maintains the material. \n<br/> MCPD (v2.1) (INSTCODE) 1. FAO WIEWS code of the institute where the accession is maintained. The codes consist of the 3-letter ISO 3166 country code of the country where the institute is located plus a number (e.g. PER001). The current set of institute codes is available from http://www.fao.org/wiews. For those institutes not yet having an FAO Code, or for those with \"obsolete\" codes, see \"Common formatting rules (v)\".",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "binomialName",
-                        "in" : "query",
-                        "description" : "List of the full binomial name (scientific name) to identify a germplasm",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "genu",
-                        "in" : "query",
-                        "description" : "List of Genus names to identify germplasm",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "specy",
-                        "in" : "query",
-                        "description" : "List of Species names to identify germplasm",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "synonym",
-                        "in" : "query",
-                        "description" : "List of alternative names or IDs used to reference this germplasm",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "includeParent",
-                        "in" : "query",
-                        "description" : "If this parameter is true, include the array of parents in the response",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "boolean"
-                        }
-                    },
-                    {
-                        "name" : "includeSibling",
-                        "in" : "query",
-                        "description" : "If this parameter is true, include the array of siblings in the response",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "boolean"
-                        }
-                    },
-                    {
-                        "name" : "includeProgeny",
-                        "in" : "query",
-                        "description" : "If this parameter is true, include the array of progeny in the response",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "boolean"
-                        }
-                    },
-                    {
-                        "name" : "includeFullTree",
-                        "in" : "query",
-                        "description" : "If this parameter is true, recursively include ALL of the nodes available in this pedigree tree",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "boolean"
-                        }
-                    },
-                    {
-                        "name" : "pedigreeDepth",
-                        "in" : "query",
-                        "description" : "Recursively include this number of levels up the tree in the response (parents, grand-parents, great-grand-parents, etc)",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "integer",
-                            "format" : "int32"
-                        }
-                    },
-                    {
-                        "name" : "progenyDepth",
-                        "in" : "query",
-                        "description" : "Recursively include this number of levels down the tree in the response (children, grand-children, great-grand-children, etc)",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "integer",
-                            "format" : "int32"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "germplasmDbId",
+                    "in" : "query",
+                    "description" : "List of IDs which uniquely identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmName",
+                    "in" : "query",
+                    "description" : "List of human readable names to identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmPUI",
+                    "in" : "query",
+                    "description" : "List of Permanent Unique Identifiers to identify germplasm",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "accessionNumber",
+                    "in" : "query",
+                    "description" : "A collection of unique identifiers for materials or germplasm within a genebank\n\nMCPD (v2.1) (ACCENUMB) 2. This is the unique identifier for accessions within a genebank, and is assigned when a sample is entered into the genebank collection (e.g. \"PI 113869\").",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "collection",
+                    "in" : "query",
+                    "description" : "A specific panel/collection/population name this germplasm belongs to.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "familyCode",
+                    "in" : "query",
+                    "description" : "A familyCode representing the family this germplasm belongs to.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "instituteCode",
+                    "in" : "query",
+                    "description" : "The code for the institute that maintains the material. \n<br/> MCPD (v2.1) (INSTCODE) 1. FAO WIEWS code of the institute where the accession is maintained. The codes consist of the 3-letter ISO 3166 country code of the country where the institute is located plus a number (e.g. PER001). The current set of institute codes is available from http://www.fao.org/wiews. For those institutes not yet having an FAO Code, or for those with \"obsolete\" codes, see \"Common formatting rules (v)\".",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "binomialName",
+                    "in" : "query",
+                    "description" : "List of the full binomial name (scientific name) to identify a germplasm",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "genu",
+                    "in" : "query",
+                    "description" : "List of Genus names to identify germplasm",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "specy",
+                    "in" : "query",
+                    "description" : "List of Species names to identify germplasm",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "synonym",
+                    "in" : "query",
+                    "description" : "List of alternative names or IDs used to reference this germplasm",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "includeParent",
+                    "in" : "query",
+                    "description" : "If this parameter is true, include the array of parents in the response",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "boolean"
+                    }
+                }, {
+                    "name" : "includeSibling",
+                    "in" : "query",
+                    "description" : "If this parameter is true, include the array of siblings in the response",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "boolean"
+                    }
+                }, {
+                    "name" : "includeProgeny",
+                    "in" : "query",
+                    "description" : "If this parameter is true, include the array of progeny in the response",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "boolean"
+                    }
+                }, {
+                    "name" : "includeFullTree",
+                    "in" : "query",
+                    "description" : "If this parameter is true, recursively include ALL of the nodes available in this pedigree tree",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "boolean"
+                    }
+                }, {
+                    "name" : "pedigreeDepth",
+                    "in" : "query",
+                    "description" : "Recursively include this number of levels up the tree in the response (parents, grand-parents, great-grand-parents, etc)",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "integer",
+                        "format" : "int32"
+                    }
+                }, {
+                    "name" : "progenyDepth",
+                    "in" : "query",
+                    "description" : "Recursively include this number of levels down the tree in the response (children, grand-children, great-grand-children, etc)",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "integer",
+                        "format" : "int32"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/PedigreeNodeListResponse"
@@ -1282,16 +1115,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "PedigreeNodes"
-                ],
+                "tags" : [ "PedigreeNodes" ],
                 "summary" : "Create new PedigreeNode",
                 "description" : "Add new PedigreeNode to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1319,108 +1148,87 @@
         },
         "/plannedcrosses" : {
             "get" : {
-                "tags" : [
-                    "Crosses"
-                ],
+                "tags" : [ "Crosses" ],
                 "summary" : "Get a filtered list of PlannedCross",
                 "description" : "Get a list of PlannedCross",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "crossingProjectDbId",
-                        "in" : "query",
-                        "description" : "Search for Crossing Projects with this unique id",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "crossingProjectName",
-                        "in" : "query",
-                        "description" : "The human readable name for a crossing project",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "plannedCrossDbId",
-                        "in" : "query",
-                        "description" : "Search for Planned Cross with this unique id",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "plannedCrossName",
-                        "in" : "query",
-                        "description" : "Search for Planned Cross with this human readable name",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "status",
-                        "in" : "query",
-                        "description" : "The status of this planned cross. Is it waiting to be performed ('TODO'), has it been completed successfully ('DONE'), or has it not been done on purpose ('SKIPPED').",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string",
-                            "enum" : [
-                                "TODO",
-                                "DONE",
-                                "SKIPPED"
-                            ]
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "crossingProjectDbId",
+                    "in" : "query",
+                    "description" : "Search for Crossing Projects with this unique id",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "crossingProjectName",
+                    "in" : "query",
+                    "description" : "The human readable name for a crossing project",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "plannedCrossDbId",
+                    "in" : "query",
+                    "description" : "Search for Planned Cross with this unique id",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "plannedCrossName",
+                    "in" : "query",
+                    "description" : "Search for Planned Cross with this human readable name",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "status",
+                    "in" : "query",
+                    "description" : "The status of this planned cross. Is it waiting to be performed ('TODO'), has it been completed successfully ('DONE'), or has it not been done on purpose ('SKIPPED').",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string",
+                        "enum" : [ "TODO", "DONE", "SKIPPED" ]
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/PlannedCrossListResponse"
@@ -1437,16 +1245,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "Crosses"
-                ],
+                "tags" : [ "Crosses" ],
                 "summary" : "Update the details for an existing PlannedCross",
                 "description" : "Update the details for an existing PlannedCross",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1472,16 +1276,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "Crosses"
-                ],
+                "tags" : [ "Crosses" ],
                 "summary" : "Create new PlannedCross",
                 "description" : "Add new PlannedCross to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1509,103 +1309,86 @@
         },
         "/seedlots" : {
             "get" : {
-                "tags" : [
-                    "SeedLots"
-                ],
+                "tags" : [ "SeedLots" ],
                 "summary" : "Get a filtered list of SeedLot",
                 "description" : "Get a list of SeedLot",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmDbId",
-                        "in" : "query",
-                        "description" : "List of IDs which uniquely identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmName",
-                        "in" : "query",
-                        "description" : "List of human readable names to identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "seedLotDbId",
-                        "in" : "query",
-                        "description" : "Unique id for a seed lot on this server",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "crossDbId",
-                        "in" : "query",
-                        "description" : "Search for Cross with this unique id",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "crossName",
-                        "in" : "query",
-                        "description" : "Search for Cross with this human readable name",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "germplasmDbId",
+                    "in" : "query",
+                    "description" : "List of IDs which uniquely identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmName",
+                    "in" : "query",
+                    "description" : "List of human readable names to identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "seedLotDbId",
+                    "in" : "query",
+                    "description" : "Unique id for a seed lot on this server",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "crossDbId",
+                    "in" : "query",
+                    "description" : "Search for Cross with this unique id",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "crossName",
+                    "in" : "query",
+                    "description" : "Search for Cross with this human readable name",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/SeedLotListResponse"
@@ -1622,16 +1405,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "SeedLots"
-                ],
+                "tags" : [ "SeedLots" ],
                 "summary" : "Create new SeedLot",
                 "description" : "Add new SeedLot to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1659,9 +1438,7 @@
         },
         "/breedingmethods/{breedingMethodDbId}" : {
             "get" : {
-                "tags" : [
-                    "Germplasm"
-                ],
+                "tags" : [ "Germplasm" ],
                 "summary" : "Get the details of a specific BreedingMethod",
                 "description" : "Get details for a BreedingMethod",
                 "responses" : {
@@ -1682,9 +1459,7 @@
         },
         "/crossingprojects/{crossingProjectDbId}" : {
             "get" : {
-                "tags" : [
-                    "CrossingProjects"
-                ],
+                "tags" : [ "CrossingProjects" ],
                 "summary" : "Get the details of a specific CrossingProject",
                 "description" : "Get details for a CrossingProject",
                 "responses" : {
@@ -1703,16 +1478,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "CrossingProjects"
-                ],
+                "tags" : [ "CrossingProjects" ],
                 "summary" : "Update the details for an existing CrossingProject",
                 "description" : "Update the details for an existing CrossingProject",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1740,9 +1511,7 @@
         },
         "/germplasm/{germplasmDbId}" : {
             "get" : {
-                "tags" : [
-                    "Germplasm"
-                ],
+                "tags" : [ "Germplasm" ],
                 "summary" : "Get the details of a specific Germplasm",
                 "description" : "Get details for a Germplasm",
                 "responses" : {
@@ -1761,16 +1530,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "Germplasm"
-                ],
+                "tags" : [ "Germplasm" ],
                 "summary" : "Update the details for an existing Germplasm",
                 "description" : "Update the details for an existing Germplasm",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1798,9 +1563,7 @@
         },
         "/attributes/{attributeDbId}" : {
             "get" : {
-                "tags" : [
-                    "GermplasmAttributes"
-                ],
+                "tags" : [ "GermplasmAttributes" ],
                 "summary" : "Get the details of a specific GermplasmAttribute",
                 "description" : "Get details for a GermplasmAttribute",
                 "responses" : {
@@ -1819,16 +1582,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "GermplasmAttributes"
-                ],
+                "tags" : [ "GermplasmAttributes" ],
                 "summary" : "Update the details for an existing GermplasmAttribute",
                 "description" : "Update the details for an existing GermplasmAttribute",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1856,9 +1615,7 @@
         },
         "/attributevalues/{attributeValueDbId}" : {
             "get" : {
-                "tags" : [
-                    "GermplasmAttributeValues"
-                ],
+                "tags" : [ "GermplasmAttributeValues" ],
                 "summary" : "Get the details of a specific GermplasmAttributeValue",
                 "description" : "Get details for a GermplasmAttributeValue",
                 "responses" : {
@@ -1877,16 +1634,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "GermplasmAttributeValues"
-                ],
+                "tags" : [ "GermplasmAttributeValues" ],
                 "summary" : "Update the details for an existing GermplasmAttributeValue",
                 "description" : "Update the details for an existing GermplasmAttributeValue",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1914,9 +1667,7 @@
         },
         "/seedlots/{seedLotDbId}" : {
             "get" : {
-                "tags" : [
-                    "SeedLots"
-                ],
+                "tags" : [ "SeedLots" ],
                 "summary" : "Get the details of a specific SeedLot",
                 "description" : "Get details for a SeedLot",
                 "responses" : {
@@ -1935,16 +1686,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "SeedLots"
-                ],
+                "tags" : [ "SeedLots" ],
                 "summary" : "Update the details for an existing SeedLot",
                 "description" : "Update the details for an existing SeedLot",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1972,9 +1719,7 @@
         },
         "/search/germplasm" : {
             "post" : {
-                "tags" : [
-                    "Germplasm"
-                ],
+                "tags" : [ "Germplasm" ],
                 "summary" : "Submit a search request for `Germplasm`",
                 "description" : "Submit a search request for `Germplasm`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/germplasm/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -1998,9 +1743,7 @@
         },
         "/search/attributes" : {
             "post" : {
-                "tags" : [
-                    "GermplasmAttributes"
-                ],
+                "tags" : [ "GermplasmAttributes" ],
                 "summary" : "Submit a search request for `GermplasmAttribute`",
                 "description" : "Submit a search request for `GermplasmAttribute`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/germplasmAttribute/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2024,9 +1767,7 @@
         },
         "/search/attributevalues" : {
             "post" : {
-                "tags" : [
-                    "GermplasmAttributeValues"
-                ],
+                "tags" : [ "GermplasmAttributeValues" ],
                 "summary" : "Submit a search request for `GermplasmAttributeValue`",
                 "description" : "Submit a search request for `GermplasmAttributeValue`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/germplasmAttributeValue/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2050,9 +1791,7 @@
         },
         "/search/pedigree" : {
             "post" : {
-                "tags" : [
-                    "PedigreeNodes"
-                ],
+                "tags" : [ "PedigreeNodes" ],
                 "summary" : "Submit a search request for `PedigreeNode`",
                 "description" : "Submit a search request for `PedigreeNode`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/pedigreeNode/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2076,9 +1815,7 @@
         },
         "/search/germplasm/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "Germplasm"
-                ],
+                "tags" : [ "Germplasm" ],
                 "summary" : "Submit a search request for `Germplasm`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/germplasm/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `Germplasm` search request <br/>\nClients should submit a search request using the corresponding `POST /search/germplasm` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2099,9 +1836,7 @@
         },
         "/search/attributes/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "GermplasmAttributes"
-                ],
+                "tags" : [ "GermplasmAttributes" ],
                 "summary" : "Submit a search request for `GermplasmAttribute`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/germplasmAttribute/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `GermplasmAttribute` search request <br/>\nClients should submit a search request using the corresponding `POST /search/germplasmAttribute` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2122,9 +1857,7 @@
         },
         "/search/attributevalues/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "GermplasmAttributeValues"
-                ],
+                "tags" : [ "GermplasmAttributeValues" ],
                 "summary" : "Submit a search request for `GermplasmAttributeValue`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/germplasmAttributeValue/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `GermplasmAttributeValue` search request <br/>\nClients should submit a search request using the corresponding `POST /search/germplasmAttributeValue` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2145,9 +1878,7 @@
         },
         "/search/pedigree/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "PedigreeNodes"
-                ],
+                "tags" : [ "PedigreeNodes" ],
                 "summary" : "Submit a search request for `PedigreeNode`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/pedigreeNode/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `PedigreeNode` search request <br/>\nClients should submit a search request using the corresponding `POST /search/pedigreeNode` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2179,12 +1910,7 @@
                 "description" : "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification."
             },
             "Attribute" : {
-                "required" : [
-                    "attributeName",
-                    "method",
-                    "scale",
-                    "trait"
-                ],
+                "required" : [ "attributeName", "method", "scale", "trait" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -2265,12 +1991,7 @@
                 }
             },
             "BreedingMethod" : {
-                "required" : [
-                    "abbreviation",
-                    "breedingMethodDbId",
-                    "breedingMethodName",
-                    "description"
-                ],
+                "required" : [ "abbreviation", "breedingMethodDbId", "breedingMethodName", "description" ],
                 "type" : "object",
                 "properties" : {
                     "abbreviation" : {
@@ -2288,9 +2009,7 @@
                 }
             },
             "Contact" : {
-                "required" : [
-                    "contactDbId"
-                ],
+                "required" : [ "contactDbId" ],
                 "type" : "object",
                 "properties" : {
                     "contactDbId" : {
@@ -2315,29 +2034,20 @@
             },
             "ContentTypes" : {
                 "type" : "string",
-                "enum" : [
-                    "application/json",
-                    "text/csv",
-                    "text/tsv",
-                    "application/flapjack"
-                ]
+                "enum" : [ "application/json", "text/csv", "text/tsv", "application/flapjack" ]
             },
             "Context" : {
                 "title" : "context",
                 "type" : "array",
                 "description" : "The JSON-LD Context is used to provide JSON-LD definitions to each field in a JSON object. By providing an array of context file urls, a BrAPI response object becomes JSON-LD compatible.  \n\nFor more information, see https://w3c.github.io/json-ld-syntax/#the-context",
-                "example" : [
-                    "https://brapi.org/jsonld/context/metadata.jsonld"
-                ],
+                "example" : [ "https://brapi.org/jsonld/context/metadata.jsonld" ],
                 "items" : {
                     "type" : "string",
                     "format" : "uri"
                 }
             },
             "Cross" : {
-                "required" : [
-                    "crossDbId"
-                ],
+                "required" : [ "crossDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -2349,15 +2059,7 @@
                     "crossType" : {
                         "type" : "string",
                         "description" : "the type of cross",
-                        "enum" : [
-                            "BIPARENTAL",
-                            "SELF",
-                            "OPEN_POLLINATED",
-                            "BULK",
-                            "BULK_SELFED",
-                            "BULK_OPEN_POLLINATED",
-                            "DOUBLE_HAPLOID"
-                        ]
+                        "enum" : [ "BIPARENTAL", "SELF", "OPEN_POLLINATED", "BULK", "BULK_SELFED", "BULK_OPEN_POLLINATED", "DOUBLE_HAPLOID" ]
                     },
                     "crossingProjectDbId" : {
                         "type" : "string"
@@ -2380,10 +2082,7 @@
                 }
             },
             "CrossNewRequest" : {
-                "required" : [
-                    "crossDbId",
-                    "crossDbId"
-                ],
+                "required" : [ "crossDbId", "crossDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -2398,15 +2097,7 @@
                     "crossType" : {
                         "type" : "string",
                         "description" : "the type of cross",
-                        "enum" : [
-                            "BIPARENTAL",
-                            "SELF",
-                            "OPEN_POLLINATED",
-                            "BULK",
-                            "BULK_SELFED",
-                            "BULK_OPEN_POLLINATED",
-                            "DOUBLE_HAPLOID"
-                        ]
+                        "enum" : [ "BIPARENTAL", "SELF", "OPEN_POLLINATED", "BULK", "BULK_SELFED", "BULK_OPEN_POLLINATED", "DOUBLE_HAPLOID" ]
                     },
                     "crossingProjectDbId" : {
                         "type" : "string"
@@ -2440,20 +2131,12 @@
                     "parentType" : {
                         "type" : "string",
                         "description" : "The type of parent ex. 'MALE', 'FEMALE', 'SELF', 'POPULATION', etc.",
-                        "enum" : [
-                            "MALE",
-                            "FEMALE",
-                            "SELF",
-                            "POPULATION"
-                        ]
+                        "enum" : [ "MALE", "FEMALE", "SELF", "POPULATION" ]
                     }
                 }
             },
             "CrossingProject" : {
-                "required" : [
-                    "crossingProjectDbId",
-                    "crossingProjectName"
-                ],
+                "required" : [ "crossingProjectDbId", "crossingProjectName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -2477,11 +2160,7 @@
                 }
             },
             "CrossingProjectNewRequest" : {
-                "required" : [
-                    "crossingProjectDbId",
-                    "crossingProjectDbId",
-                    "crossingProjectName"
-                ],
+                "required" : [ "crossingProjectDbId", "crossingProjectDbId", "crossingProjectName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -2531,52 +2210,43 @@
                 "description" : "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.\n\nCopied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
             },
             "GeoJSONGeometry" : {
-                "oneOf" : [
-                    {
-                        "required" : [
-                            "coordinateDbIds",
-                            "type"
-                        ],
-                        "type" : "object",
-                        "properties" : {
-                            "coordinates" : {
-                                "type" : "array",
-                                "items" : {
-                                    "type" : "number"
-                                }
-                            },
-                            "type" : {
-                                "type" : "string"
+                "oneOf" : [ {
+                    "required" : [ "coordinateDbIds", "type" ],
+                    "type" : "object",
+                    "properties" : {
+                        "coordinates" : {
+                            "type" : "array",
+                            "items" : {
+                                "type" : "number"
                             }
                         },
-                        "description" : "Copied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
+                        "type" : {
+                            "type" : "string"
+                        }
                     },
-                    {
-                        "required" : [
-                            "coordinateDbIds",
-                            "type"
-                        ],
-                        "type" : "object",
-                        "properties" : {
-                            "coordinates" : {
+                    "description" : "Copied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
+                }, {
+                    "required" : [ "coordinateDbIds", "type" ],
+                    "type" : "object",
+                    "properties" : {
+                        "coordinates" : {
+                            "type" : "array",
+                            "items" : {
                                 "type" : "array",
                                 "items" : {
                                     "type" : "array",
                                     "items" : {
-                                        "type" : "array",
-                                        "items" : {
-                                            "type" : "number"
-                                        }
+                                        "type" : "number"
                                     }
                                 }
-                            },
-                            "type" : {
-                                "type" : "string"
                             }
                         },
-                        "description" : "An array of Linear Rings. Each Linear Ring is an array of Points. \n\nA Point is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
-                    }
-                ]
+                        "type" : {
+                            "type" : "string"
+                        }
+                    },
+                    "description" : "An array of Linear Rings. Each Linear Ring is an array of Points. \n\nA Point is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
+                } ]
             },
             "GeoJSONSearchArea" : {
                 "type" : "object",
@@ -2590,12 +2260,7 @@
                 }
             },
             "Germplasm" : {
-                "required" : [
-                    "commonCropName",
-                    "germplasmDbId",
-                    "germplasmName",
-                    "germplasmPUI"
-                ],
+                "required" : [ "commonCropName", "germplasmDbId", "germplasmName", "germplasmPUI" ],
                 "type" : "object",
                 "properties" : {
                     "accessionNumber" : {
@@ -2610,29 +2275,7 @@
                     "biologicalStatusOfAccessionCode" : {
                         "type" : "string",
                         "description" : "MCPD (v2.1) (SAMPSTAT) 19. The coding scheme proposed can be used at 3 different levels of detail: either by using the general codes such as 100, 200, 300, 400, or by using the more specific codes such as 110, 120, etc. \n\n100) Wild \n110) Natural \n120) Semi-natural/wild \n130) Semi-natural/sown \n200) Weedy \n300) Traditional cultivar/landrace \n400) Breeding/research material \n410) Breeders line \n411) Synthetic population \n412) Hybrid \n413) Founder stock/base population \n414) Inbred line (parent of hybrid cultivar) \n415) Segregating population \n416) Clonal selection \n420) Genetic stock \n421) Mutant (e.g. induced/insertion mutants, tilling populations) \n422) Cytogenetic stocks (e.g. chromosome addition/substitution, aneuploids,  amphiploids) \n423) Other genetic stocks (e.g. mapping populations) \n500) Advanced or improved cultivar (conventional breeding methods) \n600) GMO (by genetic engineering) \n999) Other (Elaborate in REMARKS field)",
-                        "enum" : [
-                            "100",
-                            "110",
-                            "120",
-                            "130",
-                            "200",
-                            "300",
-                            "400",
-                            "410",
-                            "411",
-                            "412",
-                            "413",
-                            "414",
-                            "415",
-                            "416",
-                            "420",
-                            "421",
-                            "422",
-                            "423",
-                            "500",
-                            "600",
-                            "999"
-                        ]
+                        "enum" : [ "100", "110", "120", "130", "200", "300", "400", "410", "411", "412", "413", "414", "415", "416", "420", "421", "422", "423", "500", "600", "999" ]
                     },
                     "biologicalStatusOfAccessionDescription" : {
                         "type" : "string"
@@ -2709,14 +2352,7 @@
                 }
             },
             "GermplasmAttribute" : {
-                "required" : [
-                    "attributeDbId",
-                    "attributeName",
-                    "methodName",
-                    "scaleDbId",
-                    "scaleName",
-                    "traitName"
-                ],
+                "required" : [ "attributeDbId", "attributeName", "methodName", "scaleDbId", "scaleName", "traitName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -2800,14 +2436,7 @@
                 }
             },
             "GermplasmAttributeNewRequest" : {
-                "required" : [
-                    "attributeDbId",
-                    "attributeName",
-                    "methodName",
-                    "scaleDbId",
-                    "scaleName",
-                    "traitName"
-                ],
+                "required" : [ "attributeDbId", "attributeName", "methodName", "scaleDbId", "scaleName", "traitName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -2898,10 +2527,7 @@
                 "properties" : { }
             },
             "GermplasmAttributeValue" : {
-                "required" : [
-                    "attributeName",
-                    "attributeValueDbId"
-                ],
+                "required" : [ "attributeName", "attributeValueDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -2934,10 +2560,7 @@
                 }
             },
             "GermplasmAttributeValueNewRequest" : {
-                "required" : [
-                    "attributeName",
-                    "attributeValueDbId"
-                ],
+                "required" : [ "attributeName", "attributeValueDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -2977,13 +2600,7 @@
                 "properties" : { }
             },
             "GermplasmNewRequest" : {
-                "required" : [
-                    "commonCropName",
-                    "germplasmDbId",
-                    "germplasmDbId",
-                    "germplasmName",
-                    "germplasmPUI"
-                ],
+                "required" : [ "commonCropName", "germplasmDbId", "germplasmDbId", "germplasmName", "germplasmPUI" ],
                 "type" : "object",
                 "properties" : {
                     "accessionNumber" : {
@@ -2998,29 +2615,7 @@
                     "biologicalStatusOfAccessionCode" : {
                         "type" : "string",
                         "description" : "MCPD (v2.1) (SAMPSTAT) 19. The coding scheme proposed can be used at 3 different levels of detail: either by using the general codes such as 100, 200, 300, 400, or by using the more specific codes such as 110, 120, etc. \n\n100) Wild \n110) Natural \n120) Semi-natural/wild \n130) Semi-natural/sown \n200) Weedy \n300) Traditional cultivar/landrace \n400) Breeding/research material \n410) Breeders line \n411) Synthetic population \n412) Hybrid \n413) Founder stock/base population \n414) Inbred line (parent of hybrid cultivar) \n415) Segregating population \n416) Clonal selection \n420) Genetic stock \n421) Mutant (e.g. induced/insertion mutants, tilling populations) \n422) Cytogenetic stocks (e.g. chromosome addition/substitution, aneuploids,  amphiploids) \n423) Other genetic stocks (e.g. mapping populations) \n500) Advanced or improved cultivar (conventional breeding methods) \n600) GMO (by genetic engineering) \n999) Other (Elaborate in REMARKS field)",
-                        "enum" : [
-                            "100",
-                            "110",
-                            "120",
-                            "130",
-                            "200",
-                            "300",
-                            "400",
-                            "410",
-                            "411",
-                            "412",
-                            "413",
-                            "414",
-                            "415",
-                            "416",
-                            "420",
-                            "421",
-                            "422",
-                            "423",
-                            "500",
-                            "600",
-                            "999"
-                        ]
+                        "enum" : [ "100", "110", "120", "130", "200", "300", "400", "410", "411", "412", "413", "414", "415", "416", "420", "421", "422", "423", "500", "600", "999" ]
                     },
                     "biologicalStatusOfAccessionDescription" : {
                         "type" : "string"
@@ -3106,23 +2701,10 @@
             "ListType" : {
                 "type" : "string",
                 "description" : "The type of objects that are referenced in a List",
-                "enum" : [
-                    "germplasm",
-                    "markers",
-                    "variants",
-                    "programs",
-                    "trials",
-                    "studies",
-                    "observationUnits",
-                    "observations",
-                    "observationVariables",
-                    "samples"
-                ]
+                "enum" : [ "germplasm", "markers", "variants", "programs", "trials", "studies", "observationUnits", "observations", "observationVariables", "samples" ]
             },
             "Method" : {
-                "required" : [
-                    "methodName"
-                ],
+                "required" : [ "methodName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3155,9 +2737,7 @@
                 }
             },
             "OntologyReference" : {
-                "required" : [
-                    "ontology"
-                ],
+                "required" : [ "ontology" ],
                 "type" : "object",
                 "properties" : {
                     "documentationLinks" : {
@@ -3170,11 +2750,7 @@
                                 },
                                 "type" : {
                                     "type" : "string",
-                                    "enum" : [
-                                        "OBO",
-                                        "RDF",
-                                        "WEBPAGE"
-                                    ]
+                                    "enum" : [ "OBO", "RDF", "WEBPAGE" ]
                                 }
                             }
                         }
@@ -3188,11 +2764,7 @@
                 }
             },
             "PedigreeNode" : {
-                "required" : [
-                    "germplasmDbId",
-                    "germplasmName",
-                    "germplasmPUI"
-                ],
+                "required" : [ "germplasmDbId", "germplasmName", "germplasmPUI" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3266,9 +2838,7 @@
                 }
             },
             "PlannedCross" : {
-                "required" : [
-                    "plannedCrossDbId"
-                ],
+                "required" : [ "plannedCrossDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3277,15 +2847,7 @@
                     "crossType" : {
                         "type" : "string",
                         "description" : "the type of cross",
-                        "enum" : [
-                            "BIPARENTAL",
-                            "SELF",
-                            "OPEN_POLLINATED",
-                            "BULK",
-                            "BULK_SELFED",
-                            "BULK_OPEN_POLLINATED",
-                            "DOUBLE_HAPLOID"
-                        ]
+                        "enum" : [ "BIPARENTAL", "SELF", "OPEN_POLLINATED", "BULK", "BULK_SELFED", "BULK_OPEN_POLLINATED", "DOUBLE_HAPLOID" ]
                     },
                     "crossingProjectDbId" : {
                         "type" : "string"
@@ -3308,19 +2870,12 @@
                     "status" : {
                         "type" : "string",
                         "description" : "The status of this planned cross. Is it waiting to be performed ('TODO'), has it been completed successfully ('DONE'), or has it not been done on purpose ('SKIPPED').",
-                        "enum" : [
-                            "TODO",
-                            "DONE",
-                            "SKIPPED"
-                        ]
+                        "enum" : [ "TODO", "DONE", "SKIPPED" ]
                     }
                 }
             },
             "Scale" : {
-                "required" : [
-                    "scaleDbId",
-                    "scaleName"
-                ],
+                "required" : [ "scaleDbId", "scaleName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3329,15 +2884,7 @@
                     "dataType" : {
                         "type" : "string",
                         "description" : "<p>Class of the scale, entries can be</p>\n<p>\"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal scale that combines the expressions of the different traits composing the complex trait. For example a severity trait might be expressed by a 2 digit and 2 character code. The first 2 digits are the percentage of the plant covered by a fungus and the 2 characters refer to the delay in development, e.g. \"75VD\" means \"75 %\" of the plant is infected and the plant is very delayed.</p>\n<p>\"Date\" - The date class is for events expressed in a time format, See ISO 8601</p>\n<p>\"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months</p>\n<p>\"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories</p>\n<p>\"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectare, branches</p>\n<p>\"Ordinal\" - Ordinal scales are scales composed of ordered categories</p>\n<p>\"Text\" - A free text is used to express the trait.</p>",
-                        "enum" : [
-                            "Code",
-                            "Date",
-                            "Duration",
-                            "Nominal",
-                            "Numerical",
-                            "Ordinal",
-                            "Text"
-                        ]
+                        "enum" : [ "Code", "Date", "Duration", "Nominal", "Numerical", "Ordinal", "Text" ]
                     },
                     "decimalPlaces" : {
                         "type" : "integer",
@@ -3386,10 +2933,7 @@
                 }
             },
             "SeedLot" : {
-                "required" : [
-                    "seedLotDbId",
-                    "seedLotName"
-                ],
+                "required" : [ "seedLotDbId", "seedLotName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3434,11 +2978,7 @@
                 }
             },
             "SeedLotNewRequest" : {
-                "required" : [
-                    "seedLotDbId",
-                    "seedLotDbId",
-                    "seedLotName"
-                ],
+                "required" : [ "seedLotDbId", "seedLotDbId", "seedLotName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3486,9 +3026,7 @@
                 }
             },
             "SeedLotTransaction" : {
-                "required" : [
-                    "transactionDbId"
-                ],
+                "required" : [ "transactionDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3524,9 +3062,7 @@
                 }
             },
             "Trait" : {
-                "required" : [
-                    "traitName"
-                ],
+                "required" : [ "traitName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3573,22 +3109,10 @@
             "TraitDataType" : {
                 "type" : "string",
                 "description" : "<p>Class of the scale, entries can be</p>\n<p>\"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal scale that combines the expressions of the different traits composing the complex trait. For example a severity trait might be expressed by a 2 digit and 2 character code. The first 2 digits are the percentage of the plant covered by a fungus and the 2 characters refer to the delay in development, e.g. \"75VD\" means \"75 %\" of the plant is infected and the plant is very delayed.</p>\n<p>\"Date\" - The date class is for events expressed in a time format, See ISO 8601</p>\n<p>\"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months</p>\n<p>\"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories</p>\n<p>\"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectare, branches</p>\n<p>\"Ordinal\" - Ordinal scales are scales composed of ordered categories</p>\n<p>\"Text\" - A free text is used to express the trait.</p>",
-                "enum" : [
-                    "Code",
-                    "Date",
-                    "Duration",
-                    "Nominal",
-                    "Numerical",
-                    "Ordinal",
-                    "Text"
-                ]
+                "enum" : [ "Code", "Date", "Duration", "Nominal", "Numerical", "Ordinal", "Text" ]
             },
             "Variable" : {
-                "required" : [
-                    "method",
-                    "scale",
-                    "trait"
-                ],
+                "required" : [ "method", "scale", "trait" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3654,10 +3178,7 @@
                 }
             },
             "basePagination" : {
-                "required" : [
-                    "currentPage",
-                    "pageSize"
-                ],
+                "required" : [ "currentPage", "pageSize" ],
                 "type" : "object",
                 "properties" : {
                     "currentPage" : {
@@ -3686,9 +3207,7 @@
                 "description" : "The pagination object is applicable only when the payload contains a \"data\" key. It describes the pagination of the data contained in the \"data\" array, as a way to identify which subset of data is being returned. \n<br> Pages are zero indexed, so the first page will be page 0 (zero)."
             },
             "dataFile" : {
-                "required" : [
-                    "fileURL"
-                ],
+                "required" : [ "fileURL" ],
                 "type" : "object",
                 "properties" : {
                     "fileURL" : {
@@ -3726,19 +3245,16 @@
                 "description" : "A dataFile contains a URL and the relevant file metadata to represent a file"
             },
             "metadata" : {
-                "allOf" : [
-                    {
-                        "$ref" : "#/components/schemas/metadataBase"
-                    },
-                    {
-                        "type" : "object",
-                        "properties" : {
-                            "pagination" : {
-                                "$ref" : "#/components/schemas/basePagination"
-                            }
+                "allOf" : [ {
+                    "$ref" : "#/components/schemas/metadataBase"
+                }, {
+                    "type" : "object",
+                    "properties" : {
+                        "pagination" : {
+                            "$ref" : "#/components/schemas/basePagination"
                         }
                     }
-                ]
+                } ]
             },
             "metadataBase" : {
                 "type" : "object",
@@ -3762,25 +3278,19 @@
                 "description" : "An object in the BrAPI standard response model that describes some information about the service call being performed. This includes supplementary data, status log messages, and pagination information."
             },
             "metadataTokenPagination" : {
-                "allOf" : [
-                    {
-                        "$ref" : "#/components/schemas/metadataBase"
-                    },
-                    {
-                        "type" : "object",
-                        "properties" : {
-                            "pagination" : {
-                                "$ref" : "#/components/schemas/tokenPagination"
-                            }
+                "allOf" : [ {
+                    "$ref" : "#/components/schemas/metadataBase"
+                }, {
+                    "type" : "object",
+                    "properties" : {
+                        "pagination" : {
+                            "$ref" : "#/components/schemas/tokenPagination"
                         }
                     }
-                ]
+                } ]
             },
             "status" : {
-                "required" : [
-                    "message",
-                    "messageType"
-                ],
+                "required" : [ "message", "messageType" ],
                 "type" : "object",
                 "properties" : {
                     "message" : {
@@ -3792,68 +3302,66 @@
                         "type" : "string",
                         "description" : "The logging level for the attached message",
                         "example" : "INFO",
-                        "enum" : [
-                            "DEBUG",
-                            "ERROR",
-                            "WARNING",
-                            "INFO"
-                        ]
+                        "enum" : [ "DEBUG", "ERROR", "WARNING", "INFO" ]
                     }
                 },
                 "description" : "An array of status messages to convey technical logging information from the server to the client."
             },
             "tokenPagination" : {
-                "allOf" : [
-                    {
-                        "$ref" : "#/components/schemas/basePagination"
-                    },
-                    {
-                        "required" : [
-                            "nextPageToken"
-                        ],
-                        "type" : "object",
-                        "properties" : {
-                            "nextPageToken" : {
-                                "type" : "string",
-                                "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the next page of data.",
-                                "example" : "cb668f63",
-                                "deprecated" : true
-                            },
-                            "currentPageToken" : {
-                                "type" : "string",
-                                "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the current page of data.",
-                                "example" : "48bc6ac1",
-                                "deprecated" : true
-                            },
-                            "prevPageToken" : {
-                                "type" : "string",
-                                "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the previous page of data.",
-                                "example" : "9659857e",
-                                "deprecated" : true
-                            }
+                "allOf" : [ {
+                    "$ref" : "#/components/schemas/basePagination"
+                }, {
+                    "required" : [ "nextPageToken" ],
+                    "type" : "object",
+                    "properties" : {
+                        "nextPageToken" : {
+                            "type" : "string",
+                            "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the next page of data.",
+                            "example" : "cb668f63",
+                            "deprecated" : true
                         },
-                        "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The pagination object is applicable only when the payload contains a \"data\" key. It describes the pagination of the data contained in the \"data\" array, as a way to identify which subset of data is being returned. \n<br>Tokenized pages are for large data sets which can not be efficiently broken into indexed pages. Use the nextPageToken and prevPageToken to construct an additional query and move to the next or previous page respectively.  ",
-                        "example" : {
-                            "currentPage" : 0,
-                            "pageSize" : 1000,
-                            "totalCount" : 10,
-                            "totalPages" : 1
+                        "currentPageToken" : {
+                            "type" : "string",
+                            "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the current page of data.",
+                            "example" : "48bc6ac1",
+                            "deprecated" : true
+                        },
+                        "prevPageToken" : {
+                            "type" : "string",
+                            "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the previous page of data.",
+                            "example" : "9659857e",
+                            "deprecated" : true
                         }
+                    },
+                    "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The pagination object is applicable only when the payload contains a \"data\" key. It describes the pagination of the data contained in the \"data\" array, as a way to identify which subset of data is being returned. \n<br>Tokenized pages are for large data sets which can not be efficiently broken into indexed pages. Use the nextPageToken and prevPageToken to construct an additional query and move to the next or previous page respectively.  ",
+                    "example" : {
+                        "currentPage" : 0,
+                        "pageSize" : 1000,
+                        "totalCount" : 10,
+                        "totalPages" : 1
                     }
-                ]
+                } ]
             }
         },
         "responses" : {
-            "ObservationVariableSingleResponse" : {
+            "401Unauthorized" : {
+                "description" : "Unauthorized",
+                "content" : {
+                    "application/json" : {
+                        "schema" : {
+                            "type" : "string"
+                        },
+                        "example" : "ERROR - 2018-10-08T18:15:11Z - Missing or expired authorization token"
+                    }
+                }
+            },
+            "GermplasmAttributeListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
-                            "title" : "ObservationVariableSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "title" : "GermplasmAttributeListResponse",
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -3863,7 +3371,48 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "$ref" : "#/components/schemas/ObservationVariable"
+                                    "required" : [ "data" ],
+                                    "type" : "object",
+                                    "properties" : {
+                                        "data" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/GermplasmAttribute"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "GermplasmListResponse" : {
+                "description" : "OK",
+                "content" : {
+                    "application/json" : {
+                        "schema" : {
+                            "title" : "GermplasmListResponse",
+                            "required" : [ "metadata", "result" ],
+                            "type" : "object",
+                            "properties" : {
+                                "@context" : {
+                                    "$ref" : "#/components/schemas/Context"
+                                },
+                                "metadata" : {
+                                    "$ref" : "#/components/schemas/metadata"
+                                },
+                                "result" : {
+                                    "required" : [ "data" ],
+                                    "type" : "object",
+                                    "properties" : {
+                                        "data" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/Germplasm"
+                                            }
+                                        }
+                                    }
                                 }
                             }
                         }
@@ -3876,10 +3425,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "SeedLotSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -3890,32 +3436,6 @@
                                 },
                                 "result" : {
                                     "$ref" : "#/components/schemas/SeedLot"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "VariantSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "VariantSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Variant"
                                 }
                             }
                         }
@@ -3956,10 +3476,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "StudySingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -3976,16 +3493,13 @@
                     }
                 }
             },
-            "MarkerPositionListResponse" : {
+            "CrossingProjectSingleResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
-                            "title" : "MarkerPositionListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "title" : "CrossingProjectSingleResponse",
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -3995,18 +3509,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/MarkerPosition"
-                                            }
-                                        }
-                                    }
+                                    "$ref" : "#/components/schemas/CrossingProject"
                                 }
                             }
                         }
@@ -4019,10 +3522,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "TrialListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4032,9 +3532,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4050,42 +3548,13 @@
                     }
                 }
             },
-            "MethodSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "MethodSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Method"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "SeedLotListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "SeedLotListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4095,9 +3564,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4113,16 +3580,13 @@
                     }
                 }
             },
-            "VariantSetListResponse" : {
+            "TrialSingleResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
-                            "title" : "VariantSetListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "title" : "TrialSingleResponse",
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4132,193 +3596,93 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "$ref" : "#/components/schemas/Trial"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "GermplasmSingleResponse" : {
+                "description" : "OK",
+                "content" : {
+                    "application/json" : {
+                        "schema" : {
+                            "title" : "GermplasmSingleResponse",
+                            "required" : [ "metadata", "result" ],
+                            "type" : "object",
+                            "properties" : {
+                                "@context" : {
+                                    "$ref" : "#/components/schemas/Context"
+                                },
+                                "metadata" : {
+                                    "$ref" : "#/components/schemas/metadata"
+                                },
+                                "result" : {
+                                    "$ref" : "#/components/schemas/Germplasm"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "SeasonSingleResponse" : {
+                "description" : "OK",
+                "content" : {
+                    "application/json" : {
+                        "schema" : {
+                            "title" : "SeasonSingleResponse",
+                            "required" : [ "metadata", "result" ],
+                            "type" : "object",
+                            "properties" : {
+                                "@context" : {
+                                    "$ref" : "#/components/schemas/Context"
+                                },
+                                "metadata" : {
+                                    "$ref" : "#/components/schemas/metadata"
+                                },
+                                "result" : {
+                                    "$ref" : "#/components/schemas/Season"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "404NotFound" : {
+                "description" : "Not Found",
+                "content" : {
+                    "application/json" : {
+                        "schema" : {
+                            "type" : "string"
+                        },
+                        "example" : "ERROR - 2018-10-08T18:15:11Z - The requested object DbId is not found"
+                    }
+                }
+            },
+            "StudyListResponse" : {
+                "description" : "OK",
+                "content" : {
+                    "application/json" : {
+                        "schema" : {
+                            "title" : "StudyListResponse",
+                            "required" : [ "metadata", "result" ],
+                            "type" : "object",
+                            "properties" : {
+                                "@context" : {
+                                    "$ref" : "#/components/schemas/Context"
+                                },
+                                "metadata" : {
+                                    "$ref" : "#/components/schemas/metadata"
+                                },
+                                "result" : {
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
                                             "type" : "array",
                                             "items" : {
-                                                "$ref" : "#/components/schemas/VariantSet"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "SampleSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "SampleSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Sample"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "CallSetListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "CallSetListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/CallSet"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "CallSetSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "CallSetSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/CallSet"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "VariantSetSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "VariantSetSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/VariantSet"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ReferenceSetSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ReferenceSetSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/ReferenceSet"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ObservationVariableListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ObservationVariableListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/ObservationVariable"
+                                                "$ref" : "#/components/schemas/Study"
                                             }
                                         }
                                     }
@@ -4334,10 +3698,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "CrossListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4347,9 +3708,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4365,16 +3724,13 @@
                     }
                 }
             },
-            "ImageSingleResponse" : {
+            "BreedingMethodSingleResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
-                            "title" : "ImageSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "title" : "BreedingMethodSingleResponse",
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4384,23 +3740,20 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "$ref" : "#/components/schemas/Image"
+                                    "$ref" : "#/components/schemas/BreedingMethod"
                                 }
                             }
                         }
                     }
                 }
             },
-            "PlateListResponse" : {
+            "LocationSingleResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
-                            "title" : "PlateListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "title" : "LocationSingleResponse",
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4410,18 +3763,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Plate"
-                                            }
-                                        }
-                                    }
+                                    "$ref" : "#/components/schemas/Location"
                                 }
                             }
                         }
@@ -4434,10 +3776,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "SeasonListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4447,9 +3786,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4465,16 +3802,13 @@
                     }
                 }
             },
-            "ObservationUnitListResponse" : {
+            "PersonSingleResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
-                            "title" : "ObservationUnitListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "title" : "PersonSingleResponse",
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4484,155 +3818,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/ObservationUnit"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ReferenceListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ReferenceListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Reference"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ObservationListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ObservationListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Observation"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "AlleleMatrixListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "AlleleMatrixListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/AlleleMatrix"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "GenomeMapSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "GenomeMapSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/GenomeMap"
+                                    "$ref" : "#/components/schemas/Person"
                                 }
                             }
                         }
@@ -4645,10 +3831,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "PersonListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4658,9 +3841,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4682,10 +3863,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "PlannedCrossListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4695,9 +3873,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4719,10 +3895,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "LocationListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4732,15 +3905,45 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
                                             "type" : "array",
                                             "items" : {
                                                 "$ref" : "#/components/schemas/Location"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "GermplasmAttributeValueListResponse" : {
+                "description" : "OK",
+                "content" : {
+                    "application/json" : {
+                        "schema" : {
+                            "title" : "GermplasmAttributeValueListResponse",
+                            "required" : [ "metadata", "result" ],
+                            "type" : "object",
+                            "properties" : {
+                                "@context" : {
+                                    "$ref" : "#/components/schemas/Context"
+                                },
+                                "metadata" : {
+                                    "$ref" : "#/components/schemas/metadata"
+                                },
+                                "result" : {
+                                    "required" : [ "data" ],
+                                    "type" : "object",
+                                    "properties" : {
+                                        "data" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/GermplasmAttributeValue"
                                             }
                                         }
                                     }
@@ -4761,16 +3964,13 @@
                     }
                 }
             },
-            "OntologySingleResponse" : {
+            "BreedingMethodListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
-                            "title" : "OntologySingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "title" : "BreedingMethodListResponse",
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4780,7 +3980,39 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "$ref" : "#/components/schemas/Ontology"
+                                    "required" : [ "data" ],
+                                    "type" : "object",
+                                    "properties" : {
+                                        "data" : {
+                                            "type" : "array",
+                                            "items" : {
+                                                "$ref" : "#/components/schemas/BreedingMethod"
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "GermplasmAttributeValueSingleResponse" : {
+                "description" : "OK",
+                "content" : {
+                    "application/json" : {
+                        "schema" : {
+                            "title" : "GermplasmAttributeValueSingleResponse",
+                            "required" : [ "metadata", "result" ],
+                            "type" : "object",
+                            "properties" : {
+                                "@context" : {
+                                    "$ref" : "#/components/schemas/Context"
+                                },
+                                "metadata" : {
+                                    "$ref" : "#/components/schemas/metadata"
+                                },
+                                "result" : {
+                                    "$ref" : "#/components/schemas/GermplasmAttributeValue"
                                 }
                             }
                         }
@@ -4793,10 +4025,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ProgramListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4806,9 +4035,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4824,79 +4051,13 @@
                     }
                 }
             },
-            "ObservationUnitSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ObservationUnitSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/ObservationUnit"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ScaleListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ScaleListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Scale"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "ListListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "ListListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4906,9 +4067,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4935,53 +4094,13 @@
                     }
                 }
             },
-            "MethodListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "MethodListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Method"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "CrossingProjectListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "CrossingProjectListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4991,9 +4110,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5009,894 +4126,13 @@
                     }
                 }
             },
-            "GermplasmAttributeSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "GermplasmAttributeSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/GermplasmAttribute"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "TraitSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "TraitSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Trait"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "401Unauthorized" : {
-                "description" : "Unauthorized",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "type" : "string"
-                        },
-                        "example" : "ERROR - 2018-10-08T18:15:11Z - Missing or expired authorization token"
-                    }
-                }
-            },
-            "GermplasmAttributeListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "GermplasmAttributeListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/GermplasmAttribute"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "GermplasmListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "GermplasmListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Germplasm"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "CrossingProjectSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "CrossingProjectSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/CrossingProject"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "EventListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "EventListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Event"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "TraitListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "TraitListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Trait"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "SampleListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "SampleListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Sample"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ReferenceSetListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ReferenceSetListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/ReferenceSet"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "TrialSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "TrialSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Trial"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "GermplasmSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "GermplasmSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Germplasm"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "SeasonSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "SeasonSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Season"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ReferenceSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ReferenceSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Reference"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "OntologyListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "OntologyListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Ontology"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "404NotFound" : {
-                "description" : "Not Found",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "type" : "string"
-                        },
-                        "example" : "ERROR - 2018-10-08T18:15:11Z - The requested object DbId is not found"
-                    }
-                }
-            },
-            "StudyListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "StudyListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Study"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ScaleSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ScaleSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Scale"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "BreedingMethodSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "BreedingMethodSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/BreedingMethod"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "CallListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "CallListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Call"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "LocationSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "LocationSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Location"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "PersonSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "PersonSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Person"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "ImageListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ImageListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Image"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "VariantListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "VariantListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/Variant"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "PlateSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "PlateSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Plate"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "GermplasmAttributeValueListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "GermplasmAttributeValueListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/GermplasmAttributeValue"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "BreedingMethodListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "BreedingMethodListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/BreedingMethod"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "GermplasmAttributeValueSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "GermplasmAttributeValueSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/GermplasmAttributeValue"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
-            "GenomeMapListResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "GenomeMapListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
-                                    "type" : "object",
-                                    "properties" : {
-                                        "data" : {
-                                            "type" : "array",
-                                            "items" : {
-                                                "$ref" : "#/components/schemas/GenomeMap"
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "PedigreeNodeListResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "PedigreeNodeListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5906,9 +4142,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5924,42 +4158,13 @@
                     }
                 }
             },
-            "ObservationSingleResponse" : {
-                "description" : "OK",
-                "content" : {
-                    "application/json" : {
-                        "schema" : {
-                            "title" : "ObservationSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
-                            "type" : "object",
-                            "properties" : {
-                                "@context" : {
-                                    "$ref" : "#/components/schemas/Context"
-                                },
-                                "metadata" : {
-                                    "$ref" : "#/components/schemas/metadata"
-                                },
-                                "result" : {
-                                    "$ref" : "#/components/schemas/Observation"
-                                }
-                            }
-                        }
-                    }
-                }
-            },
             "ListSingleResponse" : {
                 "description" : "OK",
                 "content" : {
                     "application/json" : {
                         "schema" : {
                             "title" : "ListSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5982,10 +4187,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ProgramSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5996,6 +4198,29 @@
                                 },
                                 "result" : {
                                     "$ref" : "#/components/schemas/Program"
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            "GermplasmAttributeSingleResponse" : {
+                "description" : "OK",
+                "content" : {
+                    "application/json" : {
+                        "schema" : {
+                            "title" : "GermplasmAttributeSingleResponse",
+                            "required" : [ "metadata", "result" ],
+                            "type" : "object",
+                            "properties" : {
+                                "@context" : {
+                                    "$ref" : "#/components/schemas/Context"
+                                },
+                                "metadata" : {
+                                    "$ref" : "#/components/schemas/metadata"
+                                },
+                                "result" : {
+                                    "$ref" : "#/components/schemas/GermplasmAttribute"
                                 }
                             }
                         }

--- a/java/core/src/test/resources/OpenAPIGenerator/BrAPI-Phenotyping.json
+++ b/java/core/src/test/resources/OpenAPIGenerator/BrAPI-Phenotyping.json
@@ -7,85 +7,72 @@
     "paths" : {
         "/events" : {
             "get" : {
-                "tags" : [
-                    "Events"
-                ],
+                "tags" : [ "Events" ],
                 "summary" : "Get a filtered list of Event",
                 "description" : "Get a list of Event",
-                "parameters" : [
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationUnitDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies an observation unit.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "eventDbId",
-                        "in" : "query",
-                        "description" : "Filter based on an Event DbId.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "eventType",
-                        "in" : "query",
-                        "description" : "Filter based on an Event Type",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "dateRangeStart",
-                        "in" : "query",
-                        "description" : "Filter based on an Event start date.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "dateRangeEnd",
-                        "in" : "query",
-                        "description" : "Filter based on an Event start date.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationUnitDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies an observation unit.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "eventDbId",
+                    "in" : "query",
+                    "description" : "Filter based on an Event DbId.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "eventType",
+                    "in" : "query",
+                    "description" : "Filter based on an Event Type",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "dateRangeStart",
+                    "in" : "query",
+                    "description" : "Filter based on an Event start date.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "dateRangeEnd",
+                    "in" : "query",
+                    "description" : "Filter based on an Event start date.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/EventListResponse"
@@ -104,207 +91,179 @@
         },
         "/images" : {
             "get" : {
-                "tags" : [
-                    "Images"
-                ],
+                "tags" : [ "Images" ],
                 "summary" : "Get a filtered list of Image",
                 "description" : "Get a list of Image",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "descriptiveOntologyTerm",
-                        "in" : "query",
-                        "description" : "A list of terms to formally describe the image to search for. Each item could be a simple Tag, an Ontology reference Id, or a full ontology URL.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "imageFileName",
-                        "in" : "query",
-                        "description" : "Image file names to search for.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "imageFileSizeMax",
-                        "in" : "query",
-                        "description" : "A maximum image file size to search for.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "integer",
-                            "format" : "int32"
-                        }
-                    },
-                    {
-                        "name" : "imageFileSizeMin",
-                        "in" : "query",
-                        "description" : "A minimum image file size to search for.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "integer",
-                            "format" : "int32"
-                        }
-                    },
-                    {
-                        "name" : "imageHeightMax",
-                        "in" : "query",
-                        "description" : "A maximum image height to search for.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "integer",
-                            "format" : "int32"
-                        }
-                    },
-                    {
-                        "name" : "imageHeightMin",
-                        "in" : "query",
-                        "description" : "A minimum image height to search for.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "integer",
-                            "format" : "int32"
-                        }
-                    },
-                    {
-                        "name" : "imageLocation",
-                        "in" : "query",
-                        "required" : false,
-                        "schema" : {
-                            "$ref" : "#/components/schemas/GeoJSONSearchArea"
-                        }
-                    },
-                    {
-                        "name" : "imageName",
-                        "in" : "query",
-                        "description" : "Human readable names to search for.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "imageTimeStampRangeEnd",
-                        "in" : "query",
-                        "description" : "The latest timestamp to search for.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "imageTimeStampRangeStart",
-                        "in" : "query",
-                        "description" : "The earliest timestamp to search for.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "imageWidthMax",
-                        "in" : "query",
-                        "description" : "A maximum image width to search for.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "integer",
-                            "format" : "int32"
-                        }
-                    },
-                    {
-                        "name" : "imageWidthMin",
-                        "in" : "query",
-                        "description" : "A minimum image width to search for.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "integer",
-                            "format" : "int32"
-                        }
-                    },
-                    {
-                        "name" : "mimeType",
-                        "in" : "query",
-                        "description" : "A set of image file types to search for.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationDbId",
-                        "in" : "query",
-                        "description" : "A list of observation Ids this image is associated with to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "imageDbId",
-                        "in" : "query",
-                        "description" : "A list of image Ids to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationUnitDbId",
-                        "in" : "query",
-                        "description" : "A set of observation unit identifiers to search for.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "descriptiveOntologyTerm",
+                    "in" : "query",
+                    "description" : "A list of terms to formally describe the image to search for. Each item could be a simple Tag, an Ontology reference Id, or a full ontology URL.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "imageFileName",
+                    "in" : "query",
+                    "description" : "Image file names to search for.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "imageFileSizeMax",
+                    "in" : "query",
+                    "description" : "A maximum image file size to search for.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "integer",
+                        "format" : "int32"
+                    }
+                }, {
+                    "name" : "imageFileSizeMin",
+                    "in" : "query",
+                    "description" : "A minimum image file size to search for.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "integer",
+                        "format" : "int32"
+                    }
+                }, {
+                    "name" : "imageHeightMax",
+                    "in" : "query",
+                    "description" : "A maximum image height to search for.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "integer",
+                        "format" : "int32"
+                    }
+                }, {
+                    "name" : "imageHeightMin",
+                    "in" : "query",
+                    "description" : "A minimum image height to search for.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "integer",
+                        "format" : "int32"
+                    }
+                }, {
+                    "name" : "imageLocation",
+                    "in" : "query",
+                    "required" : false,
+                    "schema" : {
+                        "$ref" : "#/components/schemas/GeoJSONSearchArea"
+                    }
+                }, {
+                    "name" : "imageName",
+                    "in" : "query",
+                    "description" : "Human readable names to search for.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "imageTimeStampRangeEnd",
+                    "in" : "query",
+                    "description" : "The latest timestamp to search for.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "imageTimeStampRangeStart",
+                    "in" : "query",
+                    "description" : "The earliest timestamp to search for.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "imageWidthMax",
+                    "in" : "query",
+                    "description" : "A maximum image width to search for.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "integer",
+                        "format" : "int32"
+                    }
+                }, {
+                    "name" : "imageWidthMin",
+                    "in" : "query",
+                    "description" : "A minimum image width to search for.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "integer",
+                        "format" : "int32"
+                    }
+                }, {
+                    "name" : "mimeType",
+                    "in" : "query",
+                    "description" : "A set of image file types to search for.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationDbId",
+                    "in" : "query",
+                    "description" : "A list of observation Ids this image is associated with to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "imageDbId",
+                    "in" : "query",
+                    "description" : "A list of image Ids to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationUnitDbId",
+                    "in" : "query",
+                    "description" : "A set of observation unit identifiers to search for.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/ImageListResponse"
@@ -321,16 +280,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "Images"
-                ],
+                "tags" : [ "Images" ],
                 "summary" : "Create new Image",
                 "description" : "Add new Image to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -358,85 +313,70 @@
         },
         "/methods" : {
             "get" : {
-                "tags" : [
-                    "Methods"
-                ],
+                "tags" : [ "Methods" ],
                 "summary" : "Get a filtered list of Method",
                 "description" : "Get a list of Method",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "ontologyDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier for an ontology definition. Use this parameter to filter results based on a specific ontology \n\n  Use `GET /ontologies` to find the list of available ontologies on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "scaleDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier for a method.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationVariableDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier for an observation variable.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "ontologyDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier for an ontology definition. Use this parameter to filter results based on a specific ontology \n\n  Use `GET /ontologies` to find the list of available ontologies on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "scaleDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier for a method.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationVariableDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier for an observation variable.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/MethodListResponse"
@@ -453,16 +393,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "Methods"
-                ],
+                "tags" : [ "Methods" ],
                 "summary" : "Create new Method",
                 "description" : "Add new Method to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -490,220 +426,190 @@
         },
         "/observations" : {
             "get" : {
-                "tags" : [
-                    "Observations"
-                ],
+                "tags" : [ "Observations" ],
                 "summary" : "Get a filtered list of Observation",
                 "description" : "Get a list of Observation",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmDbId",
-                        "in" : "query",
-                        "description" : "List of IDs which uniquely identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmName",
-                        "in" : "query",
-                        "description" : "List of human readable names to identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "locationDbId",
-                        "in" : "query",
-                        "description" : "The location ids to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "locationName",
-                        "in" : "query",
-                        "description" : "A human readable names to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationVariableDbId",
-                        "in" : "query",
-                        "description" : "The DbIds of Variables to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationVariableName",
-                        "in" : "query",
-                        "description" : "The names of Variables to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationVariablePUI",
-                        "in" : "query",
-                        "description" : "The Permanent Unique Identifier of an Observation Variable, usually in the form of a URI",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationDbId",
-                        "in" : "query",
-                        "description" : "The unique id of an Observation",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationUnitDbId",
-                        "in" : "query",
-                        "description" : "The unique id of an Observation Unit",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationLevel",
-                        "in" : "query",
-                        "description" : "Searches for values in ObservationUnit->observationUnitPosition->observationLevel",
-                        "required" : false,
-                        "schema" : {
-                            "$ref" : "#/components/schemas/ObservationUnitLevel"
-                        }
-                    },
-                    {
-                        "name" : "observationLevelRelationship",
-                        "in" : "query",
-                        "description" : "Searches for values in ObservationUnit->observationUnitPosition->observationLevelRelationships",
-                        "required" : false,
-                        "schema" : {
-                            "$ref" : "#/components/schemas/ObservationUnitLevelRelationship"
-                        }
-                    },
-                    {
-                        "name" : "observationTimeStampRangeEnd",
-                        "in" : "query",
-                        "description" : "Timestamp range end",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationTimeStampRangeStart",
-                        "in" : "query",
-                        "description" : "Timestamp range start",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "seasonDbId",
-                        "in" : "query",
-                        "description" : "The year or Phenotyping campaign of a multi-annual study (trees, grape, ...)",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "germplasmDbId",
+                    "in" : "query",
+                    "description" : "List of IDs which uniquely identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmName",
+                    "in" : "query",
+                    "description" : "List of human readable names to identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "locationDbId",
+                    "in" : "query",
+                    "description" : "The location ids to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "locationName",
+                    "in" : "query",
+                    "description" : "A human readable names to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationVariableDbId",
+                    "in" : "query",
+                    "description" : "The DbIds of Variables to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationVariableName",
+                    "in" : "query",
+                    "description" : "The names of Variables to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationVariablePUI",
+                    "in" : "query",
+                    "description" : "The Permanent Unique Identifier of an Observation Variable, usually in the form of a URI",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationDbId",
+                    "in" : "query",
+                    "description" : "The unique id of an Observation",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationUnitDbId",
+                    "in" : "query",
+                    "description" : "The unique id of an Observation Unit",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationLevel",
+                    "in" : "query",
+                    "description" : "Searches for values in ObservationUnit->observationUnitPosition->observationLevel",
+                    "required" : false,
+                    "schema" : {
+                        "$ref" : "#/components/schemas/ObservationUnitLevel"
+                    }
+                }, {
+                    "name" : "observationLevelRelationship",
+                    "in" : "query",
+                    "description" : "Searches for values in ObservationUnit->observationUnitPosition->observationLevelRelationships",
+                    "required" : false,
+                    "schema" : {
+                        "$ref" : "#/components/schemas/ObservationUnitLevelRelationship"
+                    }
+                }, {
+                    "name" : "observationTimeStampRangeEnd",
+                    "in" : "query",
+                    "description" : "Timestamp range end",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationTimeStampRangeStart",
+                    "in" : "query",
+                    "description" : "Timestamp range start",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "seasonDbId",
+                    "in" : "query",
+                    "description" : "The year or Phenotyping campaign of a multi-annual study (trees, grape, ...)",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/ObservationListResponse"
@@ -720,16 +626,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "Observations"
-                ],
+                "tags" : [ "Observations" ],
                 "summary" : "Update the details for an existing Observation",
                 "description" : "Update the details for an existing Observation",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -755,16 +657,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "Observations"
-                ],
+                "tags" : [ "Observations" ],
                 "summary" : "Create new Observation",
                 "description" : "Add new Observation to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -792,211 +690,182 @@
         },
         "/observationunits" : {
             "get" : {
-                "tags" : [
-                    "ObservationUnits"
-                ],
+                "tags" : [ "ObservationUnits" ],
                 "summary" : "Get a filtered list of ObservationUnit",
                 "description" : "Get a list of ObservationUnit",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmDbId",
-                        "in" : "query",
-                        "description" : "List of IDs which uniquely identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "germplasmName",
-                        "in" : "query",
-                        "description" : "List of human readable names to identify germplasm to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "locationDbId",
-                        "in" : "query",
-                        "description" : "The location ids to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "locationName",
-                        "in" : "query",
-                        "description" : "A human readable names to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationVariableDbId",
-                        "in" : "query",
-                        "description" : "The DbIds of Variables to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationVariableName",
-                        "in" : "query",
-                        "description" : "The names of Variables to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationVariablePUI",
-                        "in" : "query",
-                        "description" : "The Permanent Unique Identifier of an Observation Variable, usually in the form of a URI",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationUnitDbId",
-                        "in" : "query",
-                        "description" : "The unique id of an observation unit",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationUnitName",
-                        "in" : "query",
-                        "description" : "The human readable identifier for an Observation Unit",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationLevel",
-                        "in" : "query",
-                        "description" : "Searches for values in ObservationUnit->observationUnitPosition->observationLevel",
-                        "required" : false,
-                        "schema" : {
-                            "$ref" : "#/components/schemas/ObservationUnitLevel"
-                        }
-                    },
-                    {
-                        "name" : "observationLevelRelationship",
-                        "in" : "query",
-                        "description" : "Searches for values in ObservationUnit->observationUnitPosition->observationLevelRelationships",
-                        "required" : false,
-                        "schema" : {
-                            "$ref" : "#/components/schemas/ObservationUnitLevelRelationship"
-                        }
-                    },
-                    {
-                        "name" : "includeObservation",
-                        "in" : "query",
-                        "description" : "Use this parameter to include a list of observations embedded in each ObservationUnit object. \n\nCAUTION - Use this parameter at your own risk. It may return large, unpaginated lists of observation data. Only set this value to True if you are sure you need to.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "boolean"
-                        }
-                    },
-                    {
-                        "name" : "seasonDbId",
-                        "in" : "query",
-                        "description" : "The year or Phenotyping campaign of a multi-annual study (trees, grape, ...)",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "germplasmDbId",
+                    "in" : "query",
+                    "description" : "List of IDs which uniquely identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "germplasmName",
+                    "in" : "query",
+                    "description" : "List of human readable names to identify germplasm to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "locationDbId",
+                    "in" : "query",
+                    "description" : "The location ids to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "locationName",
+                    "in" : "query",
+                    "description" : "A human readable names to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationVariableDbId",
+                    "in" : "query",
+                    "description" : "The DbIds of Variables to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationVariableName",
+                    "in" : "query",
+                    "description" : "The names of Variables to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationVariablePUI",
+                    "in" : "query",
+                    "description" : "The Permanent Unique Identifier of an Observation Variable, usually in the form of a URI",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationUnitDbId",
+                    "in" : "query",
+                    "description" : "The unique id of an observation unit",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationUnitName",
+                    "in" : "query",
+                    "description" : "The human readable identifier for an Observation Unit",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationLevel",
+                    "in" : "query",
+                    "description" : "Searches for values in ObservationUnit->observationUnitPosition->observationLevel",
+                    "required" : false,
+                    "schema" : {
+                        "$ref" : "#/components/schemas/ObservationUnitLevel"
+                    }
+                }, {
+                    "name" : "observationLevelRelationship",
+                    "in" : "query",
+                    "description" : "Searches for values in ObservationUnit->observationUnitPosition->observationLevelRelationships",
+                    "required" : false,
+                    "schema" : {
+                        "$ref" : "#/components/schemas/ObservationUnitLevelRelationship"
+                    }
+                }, {
+                    "name" : "includeObservation",
+                    "in" : "query",
+                    "description" : "Use this parameter to include a list of observations embedded in each ObservationUnit object. \n\nCAUTION - Use this parameter at your own risk. It may return large, unpaginated lists of observation data. Only set this value to True if you are sure you need to.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "boolean"
+                    }
+                }, {
+                    "name" : "seasonDbId",
+                    "in" : "query",
+                    "description" : "The year or Phenotyping campaign of a multi-annual study (trees, grape, ...)",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/ObservationUnitListResponse"
@@ -1013,16 +882,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "ObservationUnits"
-                ],
+                "tags" : [ "ObservationUnits" ],
                 "summary" : "Update the details for an existing ObservationUnit",
                 "description" : "Update the details for an existing ObservationUnit",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1048,16 +913,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "ObservationUnits"
-                ],
+                "tags" : [ "ObservationUnits" ],
                 "summary" : "Create new ObservationUnit",
                 "description" : "Add new ObservationUnit to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1085,274 +946,238 @@
         },
         "/variables" : {
             "get" : {
-                "tags" : [
-                    "ObservationVariables"
-                ],
+                "tags" : [ "ObservationVariables" ],
                 "summary" : "Get a filtered list of ObservationVariable",
                 "description" : "Get a list of ObservationVariable",
-                "parameters" : [
-                    {
-                        "name" : "observationVariableDbId",
-                        "in" : "query",
-                        "description" : "The DbIds of Variables to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationVariableName",
-                        "in" : "query",
-                        "description" : "The names of Variables to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationVariablePUI",
-                        "in" : "query",
-                        "description" : "The Permanent Unique Identifier of an Observation Variable, usually in the form of a URI",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "List of study identifiers to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyName",
-                        "in" : "query",
-                        "description" : "List of study names to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialDbId",
-                        "in" : "query",
-                        "description" : "The ID which uniquely identifies a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "trialName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trial to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "studyDbId",
-                        "in" : "query",
-                        "description" : "**Deprecated in v2.1** Please use `studyDbIds`. Github issue number #483 \n<br>The unique ID of a studies to filter on",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "ontologyDbId",
-                        "in" : "query",
-                        "description" : "List of ontology IDs to search for",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "methodDbId",
-                        "in" : "query",
-                        "description" : "List of methods to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "methodName",
-                        "in" : "query",
-                        "description" : "Human readable name for the method\n<br/>MIAPPE V1.1 (DM-88) Method  Name of the method of observation",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "methodPUI",
-                        "in" : "query",
-                        "description" : "The Permanent Unique Identifier of a Method, usually in the form of a URI",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "scaleDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier for a Scale",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "scaleName",
-                        "in" : "query",
-                        "description" : "Name of the scale\n<br/>MIAPPE V1.1 (DM-92) Scale Name of the scale associated with the variable",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "scalePUI",
-                        "in" : "query",
-                        "description" : "The Permanent Unique Identifier of a Scale, usually in the form of a URI",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "dataType",
-                        "in" : "query",
-                        "description" : "List of scale data types to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "$ref" : "#/components/schemas/TraitDataType"
-                        }
-                    },
-                    {
-                        "name" : "traitClass",
-                        "in" : "query",
-                        "description" : "List of trait classes to filter search results",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "traitDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier for a Trait",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "traitName",
-                        "in" : "query",
-                        "description" : "The human readable name of a trait\n<br/>MIAPPE V1.1 (DM-86) Trait - Name of the (plant or environmental) trait under observation",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "traitPUI",
-                        "in" : "query",
-                        "description" : "The Permanent Unique Identifier of a Trait, usually in the form of a URI",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "traitAttribute",
-                        "in" : "query",
-                        "description" : "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the attribute is the observed feature (or characteristic) of the entity e.g., for \"grain colour\", attribute = \"colour\"",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "traitAttributePUI",
-                        "in" : "query",
-                        "description" : "The Permanent Unique Identifier of a Trait Attribute, usually in the form of a URI\n<br/>A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the attribute is the observed feature (or characteristic) of the entity e.g., for \"grain colour\", attribute = \"colour\"",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "traitEntity",
-                        "in" : "query",
-                        "description" : "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the entity is the part of the plant that the trait refers to e.g., for \"grain colour\", entity = \"grain\"",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "traitEntityPUI",
-                        "in" : "query",
-                        "description" : "The Permanent Unique Identifier of a Trait Entity, usually in the form of a URI\n<br/>A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the entity is the part of the plant that the trait refers to e.g., for \"grain colour\", entity = \"grain\" ",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "observationVariableDbId",
+                    "in" : "query",
+                    "description" : "The DbIds of Variables to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "observationVariableName",
+                    "in" : "query",
+                    "description" : "The names of Variables to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationVariablePUI",
+                    "in" : "query",
+                    "description" : "The Permanent Unique Identifier of an Observation Variable, usually in the form of a URI",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "List of study identifiers to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyName",
+                    "in" : "query",
+                    "description" : "List of study names to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialDbId",
+                    "in" : "query",
+                    "description" : "The ID which uniquely identifies a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "trialName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trial to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "studyDbId",
+                    "in" : "query",
+                    "description" : "**Deprecated in v2.1** Please use `studyDbIds`. Github issue number #483 \n<br>The unique ID of a studies to filter on",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "ontologyDbId",
+                    "in" : "query",
+                    "description" : "List of ontology IDs to search for",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "methodDbId",
+                    "in" : "query",
+                    "description" : "List of methods to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "methodName",
+                    "in" : "query",
+                    "description" : "Human readable name for the method\n<br/>MIAPPE V1.1 (DM-88) Method  Name of the method of observation",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "methodPUI",
+                    "in" : "query",
+                    "description" : "The Permanent Unique Identifier of a Method, usually in the form of a URI",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "scaleDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier for a Scale",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "scaleName",
+                    "in" : "query",
+                    "description" : "Name of the scale\n<br/>MIAPPE V1.1 (DM-92) Scale Name of the scale associated with the variable",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "scalePUI",
+                    "in" : "query",
+                    "description" : "The Permanent Unique Identifier of a Scale, usually in the form of a URI",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "dataType",
+                    "in" : "query",
+                    "description" : "List of scale data types to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "$ref" : "#/components/schemas/TraitDataType"
+                    }
+                }, {
+                    "name" : "traitClass",
+                    "in" : "query",
+                    "description" : "List of trait classes to filter search results",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "traitDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier for a Trait",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "traitName",
+                    "in" : "query",
+                    "description" : "The human readable name of a trait\n<br/>MIAPPE V1.1 (DM-86) Trait - Name of the (plant or environmental) trait under observation",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "traitPUI",
+                    "in" : "query",
+                    "description" : "The Permanent Unique Identifier of a Trait, usually in the form of a URI",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "traitAttribute",
+                    "in" : "query",
+                    "description" : "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the attribute is the observed feature (or characteristic) of the entity e.g., for \"grain colour\", attribute = \"colour\"",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "traitAttributePUI",
+                    "in" : "query",
+                    "description" : "The Permanent Unique Identifier of a Trait Attribute, usually in the form of a URI\n<br/>A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the attribute is the observed feature (or characteristic) of the entity e.g., for \"grain colour\", attribute = \"colour\"",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "traitEntity",
+                    "in" : "query",
+                    "description" : "A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the entity is the part of the plant that the trait refers to e.g., for \"grain colour\", entity = \"grain\"",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "traitEntityPUI",
+                    "in" : "query",
+                    "description" : "The Permanent Unique Identifier of a Trait Entity, usually in the form of a URI\n<br/>A trait can be decomposed as \"Trait\" = \"Entity\" + \"Attribute\", the entity is the part of the plant that the trait refers to e.g., for \"grain colour\", entity = \"grain\" ",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/ObservationVariableListResponse"
@@ -1369,16 +1194,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "ObservationVariables"
-                ],
+                "tags" : [ "ObservationVariables" ],
                 "summary" : "Create new ObservationVariable",
                 "description" : "Add new ObservationVariable to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1406,40 +1227,32 @@
         },
         "/ontologies" : {
             "get" : {
-                "tags" : [
-                    "Ontologies"
-                ],
+                "tags" : [ "Ontologies" ],
                 "summary" : "Get a filtered list of Ontology",
                 "description" : "Get a list of Ontology",
-                "parameters" : [
-                    {
-                        "name" : "ontologyDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier for an ontology definition. Use this parameter to filter results based on a specific ontology \n\n  Use `GET /ontologies` to find the list of available ontologies on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "ontologyName",
-                        "in" : "query",
-                        "description" : "The human readable identifier for an ontology definition.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "ontologyDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier for an ontology definition. Use this parameter to filter results based on a specific ontology \n\n  Use `GET /ontologies` to find the list of available ontologies on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "ontologyName",
+                    "in" : "query",
+                    "description" : "The human readable identifier for an ontology definition.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/OntologyListResponse"
@@ -1456,16 +1269,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "Ontologies"
-                ],
+                "tags" : [ "Ontologies" ],
                 "summary" : "Create new Ontology",
                 "description" : "Add new Ontology to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1493,85 +1302,70 @@
         },
         "/scales" : {
             "get" : {
-                "tags" : [
-                    "Scales"
-                ],
+                "tags" : [ "Scales" ],
                 "summary" : "Get a filtered list of Scale",
                 "description" : "Get a list of Scale",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "ontologyDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier for an ontology definition. Use this parameter to filter results based on a specific ontology \n\n  Use `GET /ontologies` to find the list of available ontologies on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "scaleDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier for a scale.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationVariableDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier for an observation variable.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "ontologyDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier for an ontology definition. Use this parameter to filter results based on a specific ontology \n\n  Use `GET /ontologies` to find the list of available ontologies on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "scaleDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier for a scale.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationVariableDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier for an observation variable.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/ScaleListResponse"
@@ -1588,16 +1382,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "Scales"
-                ],
+                "tags" : [ "Scales" ],
                 "summary" : "Create new Scale",
                 "description" : "Add new Scale to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1625,85 +1415,70 @@
         },
         "/traits" : {
             "get" : {
-                "tags" : [
-                    "Traits"
-                ],
+                "tags" : [ "Traits" ],
                 "summary" : "Get a filtered list of Trait",
                 "description" : "Get a list of Trait",
-                "parameters" : [
-                    {
-                        "name" : "commonCropName",
-                        "in" : "query",
-                        "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "ontologyDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier for an ontology definition. Use this parameter to filter results based on a specific ontology \n\n  Use `GET /ontologies` to find the list of available ontologies on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programDbId",
-                        "in" : "query",
-                        "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "programName",
-                        "in" : "query",
-                        "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "traitDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier for a trait.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "name" : "observationVariableDbId",
-                        "in" : "query",
-                        "description" : "The unique identifier for an observation variable.",
-                        "required" : false,
-                        "schema" : {
-                            "type" : "string"
-                        }
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceID"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceId"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/externalReferenceSource"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/page"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/pageSize"
-                    },
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
+                "parameters" : [ {
+                    "name" : "commonCropName",
+                    "in" : "query",
+                    "description" : "The BrAPI Common Crop Name is the simple, generalized, widely accepted name of the organism being researched. It is most often used in multi-crop systems where digital resources need to be divided at a high level. Things like 'Maize', 'Wheat', and 'Rice' are examples of common crop names.\n\nUse this parameter to only return results associated with the given crops. \n\nUse `GET /commoncropnames` to find the list of available crops on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
                     }
-                ],
+                }, {
+                    "name" : "ontologyDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier for an ontology definition. Use this parameter to filter results based on a specific ontology \n\n  Use `GET /ontologies` to find the list of available ontologies on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programDbId",
+                    "in" : "query",
+                    "description" : "A BrAPI Program represents the high level organization or group who is responsible for conducting trials and studies. Things like Breeding Programs and Funded Projects are considered BrAPI Programs. \n\nUse this parameter to only return results associated with the given programs. \n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "programName",
+                    "in" : "query",
+                    "description" : "Use this parameter to only return results associated with the given program names. Program names are not required to be unique.\n\nUse `GET /programs` to find the list of available programs on a server.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "traitDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier for a trait.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "name" : "observationVariableDbId",
+                    "in" : "query",
+                    "description" : "The unique identifier for an observation variable.",
+                    "required" : false,
+                    "schema" : {
+                        "type" : "string"
+                    }
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceID"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceId"
+                }, {
+                    "$ref" : "#/components/parameters/externalReferenceSource"
+                }, {
+                    "$ref" : "#/components/parameters/page"
+                }, {
+                    "$ref" : "#/components/parameters/pageSize"
+                }, {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "responses" : {
                     "200" : {
                         "$ref" : "#/components/responses/TraitListResponse"
@@ -1720,16 +1495,12 @@
                 }
             },
             "post" : {
-                "tags" : [
-                    "Traits"
-                ],
+                "tags" : [ "Traits" ],
                 "summary" : "Create new Trait",
                 "description" : "Add new Trait to database",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1757,9 +1528,7 @@
         },
         "/images/{imageDbId}" : {
             "get" : {
-                "tags" : [
-                    "Images"
-                ],
+                "tags" : [ "Images" ],
                 "summary" : "Get the details of a specific Image",
                 "description" : "Get details for a Image",
                 "responses" : {
@@ -1778,16 +1547,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "Images"
-                ],
+                "tags" : [ "Images" ],
                 "summary" : "Update the details for an existing Image",
                 "description" : "Update the details for an existing Image",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1815,9 +1580,7 @@
         },
         "/methods/{methodDbId}" : {
             "get" : {
-                "tags" : [
-                    "Methods"
-                ],
+                "tags" : [ "Methods" ],
                 "summary" : "Get the details of a specific Method",
                 "description" : "Get details for a Method",
                 "responses" : {
@@ -1836,16 +1599,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "Methods"
-                ],
+                "tags" : [ "Methods" ],
                 "summary" : "Update the details for an existing Method",
                 "description" : "Update the details for an existing Method",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1873,9 +1632,7 @@
         },
         "/observations/{observationDbId}" : {
             "get" : {
-                "tags" : [
-                    "Observations"
-                ],
+                "tags" : [ "Observations" ],
                 "summary" : "Get the details of a specific Observation",
                 "description" : "Get details for a Observation",
                 "responses" : {
@@ -1896,9 +1653,7 @@
         },
         "/observationunits/{observationUnitDbId}" : {
             "get" : {
-                "tags" : [
-                    "ObservationUnits"
-                ],
+                "tags" : [ "ObservationUnits" ],
                 "summary" : "Get the details of a specific ObservationUnit",
                 "description" : "Get details for a ObservationUnit",
                 "responses" : {
@@ -1919,9 +1674,7 @@
         },
         "/variables/{observationVariableDbId}" : {
             "get" : {
-                "tags" : [
-                    "ObservationVariables"
-                ],
+                "tags" : [ "ObservationVariables" ],
                 "summary" : "Get the details of a specific ObservationVariable",
                 "description" : "Get details for a ObservationVariable",
                 "responses" : {
@@ -1940,16 +1693,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "ObservationVariables"
-                ],
+                "tags" : [ "ObservationVariables" ],
                 "summary" : "Update the details for an existing ObservationVariable",
                 "description" : "Update the details for an existing ObservationVariable",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -1977,9 +1726,7 @@
         },
         "/ontologies/{ontologyDbId}" : {
             "get" : {
-                "tags" : [
-                    "Ontologies"
-                ],
+                "tags" : [ "Ontologies" ],
                 "summary" : "Get the details of a specific Ontology",
                 "description" : "Get details for a Ontology",
                 "responses" : {
@@ -1998,16 +1745,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "Ontologies"
-                ],
+                "tags" : [ "Ontologies" ],
                 "summary" : "Update the details for an existing Ontology",
                 "description" : "Update the details for an existing Ontology",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -2035,9 +1778,7 @@
         },
         "/scales/{scaleDbId}" : {
             "get" : {
-                "tags" : [
-                    "Scales"
-                ],
+                "tags" : [ "Scales" ],
                 "summary" : "Get the details of a specific Scale",
                 "description" : "Get details for a Scale",
                 "responses" : {
@@ -2056,16 +1797,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "Scales"
-                ],
+                "tags" : [ "Scales" ],
                 "summary" : "Update the details for an existing Scale",
                 "description" : "Update the details for an existing Scale",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -2093,9 +1830,7 @@
         },
         "/traits/{traitDbId}" : {
             "get" : {
-                "tags" : [
-                    "Traits"
-                ],
+                "tags" : [ "Traits" ],
                 "summary" : "Get the details of a specific Trait",
                 "description" : "Get details for a Trait",
                 "responses" : {
@@ -2114,16 +1849,12 @@
                 }
             },
             "put" : {
-                "tags" : [
-                    "Traits"
-                ],
+                "tags" : [ "Traits" ],
                 "summary" : "Update the details for an existing Trait",
                 "description" : "Update the details for an existing Trait",
-                "parameters" : [
-                    {
-                        "$ref" : "#/components/parameters/authorizationHeader"
-                    }
-                ],
+                "parameters" : [ {
+                    "$ref" : "#/components/parameters/authorizationHeader"
+                } ],
                 "requestBody" : {
                     "content" : {
                         "application/json" : {
@@ -2151,9 +1882,7 @@
         },
         "/search/images" : {
             "post" : {
-                "tags" : [
-                    "Images"
-                ],
+                "tags" : [ "Images" ],
                 "summary" : "Submit a search request for `Image`",
                 "description" : "Submit a search request for `Image`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/image/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2177,9 +1906,7 @@
         },
         "/search/observations" : {
             "post" : {
-                "tags" : [
-                    "Observations"
-                ],
+                "tags" : [ "Observations" ],
                 "summary" : "Submit a search request for `Observation`",
                 "description" : "Submit a search request for `Observation`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/observation/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2203,9 +1930,7 @@
         },
         "/search/observationunits" : {
             "post" : {
-                "tags" : [
-                    "ObservationUnits"
-                ],
+                "tags" : [ "ObservationUnits" ],
                 "summary" : "Submit a search request for `ObservationUnit`",
                 "description" : "Submit a search request for `ObservationUnit`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/observationUnit/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2229,9 +1954,7 @@
         },
         "/search/variables" : {
             "post" : {
-                "tags" : [
-                    "ObservationVariables"
-                ],
+                "tags" : [ "ObservationVariables" ],
                 "summary" : "Submit a search request for `ObservationVariable`",
                 "description" : "Submit a search request for `ObservationVariable`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/observationVariable/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2255,9 +1978,7 @@
         },
         "/search/images/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "Images"
-                ],
+                "tags" : [ "Images" ],
                 "summary" : "Submit a search request for `Image`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/image/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `Image` search request <br/>\nClients should submit a search request using the corresponding `POST /search/image` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2278,9 +1999,7 @@
         },
         "/search/observations/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "Observations"
-                ],
+                "tags" : [ "Observations" ],
                 "summary" : "Submit a search request for `Observation`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/observation/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `Observation` search request <br/>\nClients should submit a search request using the corresponding `POST /search/observation` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2301,9 +2020,7 @@
         },
         "/search/observationunits/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "ObservationUnits"
-                ],
+                "tags" : [ "ObservationUnits" ],
                 "summary" : "Submit a search request for `ObservationUnit`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/observationUnit/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `ObservationUnit` search request <br/>\nClients should submit a search request using the corresponding `POST /search/observationUnit` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2324,9 +2041,7 @@
         },
         "/search/variables/{searchResultsDbId}" : {
             "get" : {
-                "tags" : [
-                    "ObservationVariables"
-                ],
+                "tags" : [ "ObservationVariables" ],
                 "summary" : "Submit a search request for `ObservationVariable`<br/>\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse the corresponding `GET /search/observationVariable/{searchResultsDbId}` to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "description" : "Get the results of a `ObservationVariable` search request <br/>\nClients should submit a search request using the corresponding `POST /search/observationVariable` endpoint.\nSearch requests allow a client to send a complex query for data. However, the server may not respond with the search results immediately. \nIf a server needs more time to process the request, it might respond with a `searchResultsDbId`. \nUse this endpoint to retrieve the results of the search. <br/> \nReview the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Search_Services#POST_Search_Entity\">Search Services documentation</a> for additional implementation details.",
                 "responses" : {
@@ -2358,12 +2073,7 @@
                 "description" : "A free space containing any additional information related to a particular object. A data source may provide any JSON object, unrestricted by the BrAPI specification."
             },
             "Attribute" : {
-                "required" : [
-                    "attributeName",
-                    "method",
-                    "scale",
-                    "trait"
-                ],
+                "required" : [ "attributeName", "method", "scale", "trait" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -2444,9 +2154,7 @@
                 }
             },
             "Contact" : {
-                "required" : [
-                    "contactDbId"
-                ],
+                "required" : [ "contactDbId" ],
                 "type" : "object",
                 "properties" : {
                     "contactDbId" : {
@@ -2471,20 +2179,13 @@
             },
             "ContentTypes" : {
                 "type" : "string",
-                "enum" : [
-                    "application/json",
-                    "text/csv",
-                    "text/tsv",
-                    "application/flapjack"
-                ]
+                "enum" : [ "application/json", "text/csv", "text/tsv", "application/flapjack" ]
             },
             "Context" : {
                 "title" : "context",
                 "type" : "array",
                 "description" : "The JSON-LD Context is used to provide JSON-LD definitions to each field in a JSON object. By providing an array of context file urls, a BrAPI response object becomes JSON-LD compatible.  \n\nFor more information, see https://w3c.github.io/json-ld-syntax/#the-context",
-                "example" : [
-                    "https://brapi.org/jsonld/context/metadata.jsonld"
-                ],
+                "example" : [ "https://brapi.org/jsonld/context/metadata.jsonld" ],
                 "items" : {
                     "type" : "string",
                     "format" : "uri"
@@ -2502,20 +2203,12 @@
                     "parentType" : {
                         "type" : "string",
                         "description" : "The type of parent ex. 'MALE', 'FEMALE', 'SELF', 'POPULATION', etc.",
-                        "enum" : [
-                            "MALE",
-                            "FEMALE",
-                            "SELF",
-                            "POPULATION"
-                        ]
+                        "enum" : [ "MALE", "FEMALE", "SELF", "POPULATION" ]
                     }
                 }
             },
             "Event" : {
-                "required" : [
-                    "eventDbId",
-                    "eventType"
-                ],
+                "required" : [ "eventDbId", "eventType" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -2592,52 +2285,43 @@
                 "description" : "One geometry as defined by GeoJSON (RFC 7946). All coordinates are decimal values on the WGS84 geographic coordinate reference system.\n\nCopied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
             },
             "GeoJSONGeometry" : {
-                "oneOf" : [
-                    {
-                        "required" : [
-                            "coordinateDbIds",
-                            "type"
-                        ],
-                        "type" : "object",
-                        "properties" : {
-                            "coordinates" : {
-                                "type" : "array",
-                                "items" : {
-                                    "type" : "number"
-                                }
-                            },
-                            "type" : {
-                                "type" : "string"
+                "oneOf" : [ {
+                    "required" : [ "coordinateDbIds", "type" ],
+                    "type" : "object",
+                    "properties" : {
+                        "coordinates" : {
+                            "type" : "array",
+                            "items" : {
+                                "type" : "number"
                             }
                         },
-                        "description" : "Copied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
+                        "type" : {
+                            "type" : "string"
+                        }
                     },
-                    {
-                        "required" : [
-                            "coordinateDbIds",
-                            "type"
-                        ],
-                        "type" : "object",
-                        "properties" : {
-                            "coordinates" : {
+                    "description" : "Copied from RFC 7946 Section 3.1.1\n\nA position is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
+                }, {
+                    "required" : [ "coordinateDbIds", "type" ],
+                    "type" : "object",
+                    "properties" : {
+                        "coordinates" : {
+                            "type" : "array",
+                            "items" : {
                                 "type" : "array",
                                 "items" : {
                                     "type" : "array",
                                     "items" : {
-                                        "type" : "array",
-                                        "items" : {
-                                            "type" : "number"
-                                        }
+                                        "type" : "number"
                                     }
                                 }
-                            },
-                            "type" : {
-                                "type" : "string"
                             }
                         },
-                        "description" : "An array of Linear Rings. Each Linear Ring is an array of Points. \n\nA Point is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
-                    }
-                ]
+                        "type" : {
+                            "type" : "string"
+                        }
+                    },
+                    "description" : "An array of Linear Rings. Each Linear Ring is an array of Points. \n\nA Point is an array of numbers. There MUST be two or more elements. The first two elements are longitude and latitude, or\neasting and northing, precisely in that order and using decimal numbers. Altitude or elevation MAY be included as an optional third element."
+                } ]
             },
             "GeoJSONSearchArea" : {
                 "type" : "object",
@@ -2651,12 +2335,7 @@
                 }
             },
             "Germplasm" : {
-                "required" : [
-                    "commonCropName",
-                    "germplasmDbId",
-                    "germplasmName",
-                    "germplasmPUI"
-                ],
+                "required" : [ "commonCropName", "germplasmDbId", "germplasmName", "germplasmPUI" ],
                 "type" : "object",
                 "properties" : {
                     "accessionNumber" : {
@@ -2671,29 +2350,7 @@
                     "biologicalStatusOfAccessionCode" : {
                         "type" : "string",
                         "description" : "MCPD (v2.1) (SAMPSTAT) 19. The coding scheme proposed can be used at 3 different levels of detail: either by using the general codes such as 100, 200, 300, 400, or by using the more specific codes such as 110, 120, etc. \n\n100) Wild \n110) Natural \n120) Semi-natural/wild \n130) Semi-natural/sown \n200) Weedy \n300) Traditional cultivar/landrace \n400) Breeding/research material \n410) Breeders line \n411) Synthetic population \n412) Hybrid \n413) Founder stock/base population \n414) Inbred line (parent of hybrid cultivar) \n415) Segregating population \n416) Clonal selection \n420) Genetic stock \n421) Mutant (e.g. induced/insertion mutants, tilling populations) \n422) Cytogenetic stocks (e.g. chromosome addition/substitution, aneuploids,  amphiploids) \n423) Other genetic stocks (e.g. mapping populations) \n500) Advanced or improved cultivar (conventional breeding methods) \n600) GMO (by genetic engineering) \n999) Other (Elaborate in REMARKS field)",
-                        "enum" : [
-                            "100",
-                            "110",
-                            "120",
-                            "130",
-                            "200",
-                            "300",
-                            "400",
-                            "410",
-                            "411",
-                            "412",
-                            "413",
-                            "414",
-                            "415",
-                            "416",
-                            "420",
-                            "421",
-                            "422",
-                            "423",
-                            "500",
-                            "600",
-                            "999"
-                        ]
+                        "enum" : [ "100", "110", "120", "130", "200", "300", "400", "410", "411", "412", "413", "414", "415", "416", "420", "421", "422", "423", "500", "600", "999" ]
                     },
                     "biologicalStatusOfAccessionDescription" : {
                         "type" : "string"
@@ -2773,9 +2430,7 @@
                 }
             },
             "Image" : {
-                "required" : [
-                    "imageDbId"
-                ],
+                "required" : [ "imageDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -2844,10 +2499,7 @@
                 }
             },
             "ImageNewRequest" : {
-                "required" : [
-                    "imageDbId",
-                    "imageDbId"
-                ],
+                "required" : [ "imageDbId", "imageDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -2959,24 +2611,10 @@
             "ListType" : {
                 "type" : "string",
                 "description" : "The type of objects that are referenced in a List",
-                "enum" : [
-                    "germplasm",
-                    "markers",
-                    "variants",
-                    "programs",
-                    "trials",
-                    "studies",
-                    "observationUnits",
-                    "observations",
-                    "observationVariables",
-                    "samples"
-                ]
+                "enum" : [ "germplasm", "markers", "variants", "programs", "trials", "studies", "observationUnits", "observations", "observationVariables", "samples" ]
             },
             "Method" : {
-                "required" : [
-                    "methodDbId",
-                    "methodName"
-                ],
+                "required" : [ "methodDbId", "methodName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3006,10 +2644,7 @@
                 }
             },
             "MethodNewRequest" : {
-                "required" : [
-                    "methodDbId",
-                    "methodName"
-                ],
+                "required" : [ "methodDbId", "methodName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3042,9 +2677,7 @@
                 }
             },
             "Observation" : {
-                "required" : [
-                    "observationDbId"
-                ],
+                "required" : [ "observationDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3119,10 +2752,7 @@
                 }
             },
             "ObservationNewRequest" : {
-                "required" : [
-                    "observationDbId",
-                    "observationDbId"
-                ],
+                "required" : [ "observationDbId", "observationDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3211,9 +2841,7 @@
                 }
             },
             "ObservationUnit" : {
-                "required" : [
-                    "observationUnitDbId"
-                ],
+                "required" : [ "observationUnitDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3252,11 +2880,7 @@
                             "entryType" : {
                                 "type" : "string",
                                 "description" : "The type of entry for this observation unit. ex. \"CHECK\", \"TEST\", \"FILLER\"",
-                                "enum" : [
-                                    "CHECK",
-                                    "TEST",
-                                    "FILLER"
-                                ]
+                                "enum" : [ "CHECK", "TEST", "FILLER" ]
                             },
                             "geoCoordinates" : {
                                 "type" : "object",
@@ -3285,16 +2909,7 @@
                             "positionCoordinateXType" : {
                                 "type" : "string",
                                 "description" : "The type of positional coordinate used. Must be one of the following values \n\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nPLANTED_ROW - The physical planted row number \n\nPLANTED_INDIVIDUAL - The physical counted number, could be independent or within a planted row \n\nGRID_ROW - The row index number of a square grid overlay \n\nGRID_COL - The column index number of a square grid overlay \n\nMEASURED_ROW - The distance in meters from a defined 0-th row \n\nMEASURED_COL - The distance in meters from a defined 0-th column ",
-                                "enum" : [
-                                    "LONGITUDE",
-                                    "LATITUDE",
-                                    "PLANTED_ROW",
-                                    "PLANTED_INDIVIDUAL",
-                                    "GRID_ROW",
-                                    "GRID_COL",
-                                    "MEASURED_ROW",
-                                    "MEASURED_COL"
-                                ]
+                                "enum" : [ "LONGITUDE", "LATITUDE", "PLANTED_ROW", "PLANTED_INDIVIDUAL", "GRID_ROW", "GRID_COL", "MEASURED_ROW", "MEASURED_COL" ]
                             },
                             "positionCoordinateY" : {
                                 "type" : "string"
@@ -3302,16 +2917,7 @@
                             "positionCoordinateYType" : {
                                 "type" : "string",
                                 "description" : "The type of positional coordinate used. Must be one of the following values \n\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nPLANTED_ROW - The physical planted row number  \n\nPLANTED_INDIVIDUAL - The physical counted number, could be independent or within a planted row \n\nGRID_ROW - The row index number of a square grid overlay \n\nGRID_COL - The column index number of a square grid overlay \n\nMEASURED_ROW - The distance in meters from a defined 0-th row \n\nMEASURED_COL - The distance in meters from a defined 0-th column ",
-                                "enum" : [
-                                    "LONGITUDE",
-                                    "LATITUDE",
-                                    "PLANTED_ROW",
-                                    "PLANTED_INDIVIDUAL",
-                                    "GRID_ROW",
-                                    "GRID_COL",
-                                    "MEASURED_ROW",
-                                    "MEASURED_COL"
-                                ]
+                                "enum" : [ "LONGITUDE", "LATITUDE", "PLANTED_ROW", "PLANTED_INDIVIDUAL", "GRID_ROW", "GRID_COL", "MEASURED_ROW", "MEASURED_COL" ]
                             }
                         },
                         "description" : "All positional and layout information related to this Observation Unit \n\nMIAPPE V1.1 (DM-73) Spatial distribution - Type and value of a spatial coordinate (georeference or relative) \nor level of observation (plot 45, subblock 7, block 2) provided as a key-value pair of the form type:value. \nLevels of observation must be consistent with those listed in the Study section."
@@ -3384,10 +2990,7 @@
                 "description" : "Observation levels indicate the granularity level at which the measurements are taken. `levelName` \ndefines the level, `levelOrder` defines where that level exists in the hierarchy of levels. \n`levelOrder`s lower numbers are at the top of the hierarchy (ie field > 0) and higher numbers are \nat the bottom of the hierarchy (ie plant > 6). `levelCode` is an ID code for this level tag. Identify \nthis observation unit by each level of the hierarchy where it exists. \n\nFor more information on Observation Levels, please review the <a target=\"_blank\" href=\"https://wiki.brapi.org/index.php/Observation_Levels\">Observation Levels documentation</a>. \n\n**Standard Level Names: study, field, entry, rep, block, sub-block, plot, sub-plot, plant, pot, sample** "
             },
             "ObservationUnitNewRequest" : {
-                "required" : [
-                    "observationUnitDbId",
-                    "observationUnitDbId"
-                ],
+                "required" : [ "observationUnitDbId", "observationUnitDbId" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3429,11 +3032,7 @@
                             "entryType" : {
                                 "type" : "string",
                                 "description" : "The type of entry for this observation unit. ex. \"CHECK\", \"TEST\", \"FILLER\"",
-                                "enum" : [
-                                    "CHECK",
-                                    "TEST",
-                                    "FILLER"
-                                ]
+                                "enum" : [ "CHECK", "TEST", "FILLER" ]
                             },
                             "geoCoordinates" : {
                                 "type" : "object",
@@ -3462,16 +3061,7 @@
                             "positionCoordinateXType" : {
                                 "type" : "string",
                                 "description" : "The type of positional coordinate used. Must be one of the following values \n\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nPLANTED_ROW - The physical planted row number \n\nPLANTED_INDIVIDUAL - The physical counted number, could be independent or within a planted row \n\nGRID_ROW - The row index number of a square grid overlay \n\nGRID_COL - The column index number of a square grid overlay \n\nMEASURED_ROW - The distance in meters from a defined 0-th row \n\nMEASURED_COL - The distance in meters from a defined 0-th column ",
-                                "enum" : [
-                                    "LONGITUDE",
-                                    "LATITUDE",
-                                    "PLANTED_ROW",
-                                    "PLANTED_INDIVIDUAL",
-                                    "GRID_ROW",
-                                    "GRID_COL",
-                                    "MEASURED_ROW",
-                                    "MEASURED_COL"
-                                ]
+                                "enum" : [ "LONGITUDE", "LATITUDE", "PLANTED_ROW", "PLANTED_INDIVIDUAL", "GRID_ROW", "GRID_COL", "MEASURED_ROW", "MEASURED_COL" ]
                             },
                             "positionCoordinateY" : {
                                 "type" : "string"
@@ -3479,16 +3069,7 @@
                             "positionCoordinateYType" : {
                                 "type" : "string",
                                 "description" : "The type of positional coordinate used. Must be one of the following values \n\nLONGITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nLATITUDE - ISO 6709 standard, WGS84 geodetic datum. See 'Location Coordinate Encoding' for details \n\nPLANTED_ROW - The physical planted row number  \n\nPLANTED_INDIVIDUAL - The physical counted number, could be independent or within a planted row \n\nGRID_ROW - The row index number of a square grid overlay \n\nGRID_COL - The column index number of a square grid overlay \n\nMEASURED_ROW - The distance in meters from a defined 0-th row \n\nMEASURED_COL - The distance in meters from a defined 0-th column ",
-                                "enum" : [
-                                    "LONGITUDE",
-                                    "LATITUDE",
-                                    "PLANTED_ROW",
-                                    "PLANTED_INDIVIDUAL",
-                                    "GRID_ROW",
-                                    "GRID_COL",
-                                    "MEASURED_ROW",
-                                    "MEASURED_COL"
-                                ]
+                                "enum" : [ "LONGITUDE", "LATITUDE", "PLANTED_ROW", "PLANTED_INDIVIDUAL", "GRID_ROW", "GRID_COL", "MEASURED_ROW", "MEASURED_COL" ]
                             }
                         },
                         "description" : "All positional and layout information related to this Observation Unit \n\nMIAPPE V1.1 (DM-73) Spatial distribution - Type and value of a spatial coordinate (georeference or relative) \nor level of observation (plot 45, subblock 7, block 2) provided as a key-value pair of the form type:value. \nLevels of observation must be consistent with those listed in the Study section."
@@ -3534,14 +3115,7 @@
                 }
             },
             "ObservationVariable" : {
-                "required" : [
-                    "methodName",
-                    "observationVariableDbId",
-                    "observationVariableName",
-                    "scaleDbId",
-                    "scaleName",
-                    "traitName"
-                ],
+                "required" : [ "methodName", "observationVariableDbId", "observationVariableName", "scaleDbId", "scaleName", "traitName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3613,15 +3187,7 @@
                 }
             },
             "ObservationVariableNewRequest" : {
-                "required" : [
-                    "methodName",
-                    "observationVariableDbId",
-                    "observationVariableDbId",
-                    "observationVariableName",
-                    "scaleDbId",
-                    "scaleName",
-                    "traitName"
-                ],
+                "required" : [ "methodName", "observationVariableDbId", "observationVariableDbId", "observationVariableName", "scaleDbId", "scaleName", "traitName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3700,10 +3266,7 @@
                 "properties" : { }
             },
             "Ontology" : {
-                "required" : [
-                    "ontologyDbId",
-                    "ontologyName"
-                ],
+                "required" : [ "ontologyDbId", "ontologyName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3733,11 +3296,7 @@
                 }
             },
             "OntologyNewRequest" : {
-                "required" : [
-                    "ontologyDbId",
-                    "ontologyDbId",
-                    "ontologyName"
-                ],
+                "required" : [ "ontologyDbId", "ontologyDbId", "ontologyName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3770,9 +3329,7 @@
                 }
             },
             "OntologyReference" : {
-                "required" : [
-                    "ontology"
-                ],
+                "required" : [ "ontology" ],
                 "type" : "object",
                 "properties" : {
                     "documentationLinks" : {
@@ -3785,11 +3342,7 @@
                                 },
                                 "type" : {
                                     "type" : "string",
-                                    "enum" : [
-                                        "OBO",
-                                        "RDF",
-                                        "WEBPAGE"
-                                    ]
+                                    "enum" : [ "OBO", "RDF", "WEBPAGE" ]
                                 }
                             }
                         }
@@ -3803,11 +3356,7 @@
                 }
             },
             "PedigreeNode" : {
-                "required" : [
-                    "germplasmDbId",
-                    "germplasmName",
-                    "germplasmPUI"
-                ],
+                "required" : [ "germplasmDbId", "germplasmName", "germplasmPUI" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3856,10 +3405,7 @@
                 }
             },
             "Scale" : {
-                "required" : [
-                    "scaleDbId",
-                    "scaleName"
-                ],
+                "required" : [ "scaleDbId", "scaleName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3868,15 +3414,7 @@
                     "dataType" : {
                         "type" : "string",
                         "description" : "<p>Class of the scale, entries can be</p>\n<p>\"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal scale that combines the expressions of the different traits composing the complex trait. For example a severity trait might be expressed by a 2 digit and 2 character code. The first 2 digits are the percentage of the plant covered by a fungus and the 2 characters refer to the delay in development, e.g. \"75VD\" means \"75 %\" of the plant is infected and the plant is very delayed.</p>\n<p>\"Date\" - The date class is for events expressed in a time format, See ISO 8601</p>\n<p>\"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months</p>\n<p>\"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories</p>\n<p>\"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectare, branches</p>\n<p>\"Ordinal\" - Ordinal scales are scales composed of ordered categories</p>\n<p>\"Text\" - A free text is used to express the trait.</p>",
-                        "enum" : [
-                            "Code",
-                            "Date",
-                            "Duration",
-                            "Nominal",
-                            "Numerical",
-                            "Ordinal",
-                            "Text"
-                        ]
+                        "enum" : [ "Code", "Date", "Duration", "Nominal", "Numerical", "Ordinal", "Text" ]
                     },
                     "decimalPlaces" : {
                         "type" : "integer",
@@ -3922,11 +3460,7 @@
                 }
             },
             "ScaleNewRequest" : {
-                "required" : [
-                    "scaleDbId",
-                    "scaleDbId",
-                    "scaleName"
-                ],
+                "required" : [ "scaleDbId", "scaleDbId", "scaleName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -3935,15 +3469,7 @@
                     "dataType" : {
                         "type" : "string",
                         "description" : "<p>Class of the scale, entries can be</p>\n<p>\"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal scale that combines the expressions of the different traits composing the complex trait. For example a severity trait might be expressed by a 2 digit and 2 character code. The first 2 digits are the percentage of the plant covered by a fungus and the 2 characters refer to the delay in development, e.g. \"75VD\" means \"75 %\" of the plant is infected and the plant is very delayed.</p>\n<p>\"Date\" - The date class is for events expressed in a time format, See ISO 8601</p>\n<p>\"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months</p>\n<p>\"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories</p>\n<p>\"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectare, branches</p>\n<p>\"Ordinal\" - Ordinal scales are scales composed of ordered categories</p>\n<p>\"Text\" - A free text is used to express the trait.</p>",
-                        "enum" : [
-                            "Code",
-                            "Date",
-                            "Duration",
-                            "Nominal",
-                            "Numerical",
-                            "Ordinal",
-                            "Text"
-                        ]
+                        "enum" : [ "Code", "Date", "Duration", "Nominal", "Numerical", "Ordinal", "Text" ]
                     },
                     "decimalPlaces" : {
                         "type" : "integer",
@@ -3992,10 +3518,7 @@
                 }
             },
             "Trait" : {
-                "required" : [
-                    "traitDbId",
-                    "traitName"
-                ],
+                "required" : [ "traitDbId", "traitName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -4039,21 +3562,10 @@
             "TraitDataType" : {
                 "type" : "string",
                 "description" : "<p>Class of the scale, entries can be</p>\n<p>\"Code\" -  This scale class is exceptionally used to express complex traits. Code is a nominal scale that combines the expressions of the different traits composing the complex trait. For example a severity trait might be expressed by a 2 digit and 2 character code. The first 2 digits are the percentage of the plant covered by a fungus and the 2 characters refer to the delay in development, e.g. \"75VD\" means \"75 %\" of the plant is infected and the plant is very delayed.</p>\n<p>\"Date\" - The date class is for events expressed in a time format, See ISO 8601</p>\n<p>\"Duration\" - The Duration class is for time elapsed between two events expressed in a time format, e.g. days, hours, months</p>\n<p>\"Nominal\" - Categorical scale that can take one of a limited and fixed number of categories. There is no intrinsic ordering to the categories</p>\n<p>\"Numerical\" - Numerical scales express the trait with real numbers. The numerical scale defines the unit e.g. centimeter, ton per hectare, branches</p>\n<p>\"Ordinal\" - Ordinal scales are scales composed of ordered categories</p>\n<p>\"Text\" - A free text is used to express the trait.</p>",
-                "enum" : [
-                    "Code",
-                    "Date",
-                    "Duration",
-                    "Nominal",
-                    "Numerical",
-                    "Ordinal",
-                    "Text"
-                ]
+                "enum" : [ "Code", "Date", "Duration", "Nominal", "Numerical", "Ordinal", "Text" ]
             },
             "TraitNewRequest" : {
-                "required" : [
-                    "traitDbId",
-                    "traitName"
-                ],
+                "required" : [ "traitDbId", "traitName" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -4098,11 +3610,7 @@
                 }
             },
             "Variable" : {
-                "required" : [
-                    "method",
-                    "scale",
-                    "trait"
-                ],
+                "required" : [ "method", "scale", "trait" ],
                 "type" : "object",
                 "properties" : {
                     "additionalInfo" : {
@@ -4168,10 +3676,7 @@
                 }
             },
             "basePagination" : {
-                "required" : [
-                    "currentPage",
-                    "pageSize"
-                ],
+                "required" : [ "currentPage", "pageSize" ],
                 "type" : "object",
                 "properties" : {
                     "currentPage" : {
@@ -4200,9 +3705,7 @@
                 "description" : "The pagination object is applicable only when the payload contains a \"data\" key. It describes the pagination of the data contained in the \"data\" array, as a way to identify which subset of data is being returned. \n<br> Pages are zero indexed, so the first page will be page 0 (zero)."
             },
             "dataFile" : {
-                "required" : [
-                    "fileURL"
-                ],
+                "required" : [ "fileURL" ],
                 "type" : "object",
                 "properties" : {
                     "fileURL" : {
@@ -4240,19 +3743,16 @@
                 "description" : "A dataFile contains a URL and the relevant file metadata to represent a file"
             },
             "metadata" : {
-                "allOf" : [
-                    {
-                        "$ref" : "#/components/schemas/metadataBase"
-                    },
-                    {
-                        "type" : "object",
-                        "properties" : {
-                            "pagination" : {
-                                "$ref" : "#/components/schemas/basePagination"
-                            }
+                "allOf" : [ {
+                    "$ref" : "#/components/schemas/metadataBase"
+                }, {
+                    "type" : "object",
+                    "properties" : {
+                        "pagination" : {
+                            "$ref" : "#/components/schemas/basePagination"
                         }
                     }
-                ]
+                } ]
             },
             "metadataBase" : {
                 "type" : "object",
@@ -4276,25 +3776,19 @@
                 "description" : "An object in the BrAPI standard response model that describes some information about the service call being performed. This includes supplementary data, status log messages, and pagination information."
             },
             "metadataTokenPagination" : {
-                "allOf" : [
-                    {
-                        "$ref" : "#/components/schemas/metadataBase"
-                    },
-                    {
-                        "type" : "object",
-                        "properties" : {
-                            "pagination" : {
-                                "$ref" : "#/components/schemas/tokenPagination"
-                            }
+                "allOf" : [ {
+                    "$ref" : "#/components/schemas/metadataBase"
+                }, {
+                    "type" : "object",
+                    "properties" : {
+                        "pagination" : {
+                            "$ref" : "#/components/schemas/tokenPagination"
                         }
                     }
-                ]
+                } ]
             },
             "status" : {
-                "required" : [
-                    "message",
-                    "messageType"
-                ],
+                "required" : [ "message", "messageType" ],
                 "type" : "object",
                 "properties" : {
                     "message" : {
@@ -4306,55 +3800,45 @@
                         "type" : "string",
                         "description" : "The logging level for the attached message",
                         "example" : "INFO",
-                        "enum" : [
-                            "DEBUG",
-                            "ERROR",
-                            "WARNING",
-                            "INFO"
-                        ]
+                        "enum" : [ "DEBUG", "ERROR", "WARNING", "INFO" ]
                     }
                 },
                 "description" : "An array of status messages to convey technical logging information from the server to the client."
             },
             "tokenPagination" : {
-                "allOf" : [
-                    {
-                        "$ref" : "#/components/schemas/basePagination"
-                    },
-                    {
-                        "required" : [
-                            "nextPageToken"
-                        ],
-                        "type" : "object",
-                        "properties" : {
-                            "nextPageToken" : {
-                                "type" : "string",
-                                "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the next page of data.",
-                                "example" : "cb668f63",
-                                "deprecated" : true
-                            },
-                            "currentPageToken" : {
-                                "type" : "string",
-                                "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the current page of data.",
-                                "example" : "48bc6ac1",
-                                "deprecated" : true
-                            },
-                            "prevPageToken" : {
-                                "type" : "string",
-                                "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the previous page of data.",
-                                "example" : "9659857e",
-                                "deprecated" : true
-                            }
+                "allOf" : [ {
+                    "$ref" : "#/components/schemas/basePagination"
+                }, {
+                    "required" : [ "nextPageToken" ],
+                    "type" : "object",
+                    "properties" : {
+                        "nextPageToken" : {
+                            "type" : "string",
+                            "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the next page of data.",
+                            "example" : "cb668f63",
+                            "deprecated" : true
                         },
-                        "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The pagination object is applicable only when the payload contains a \"data\" key. It describes the pagination of the data contained in the \"data\" array, as a way to identify which subset of data is being returned. \n<br>Tokenized pages are for large data sets which can not be efficiently broken into indexed pages. Use the nextPageToken and prevPageToken to construct an additional query and move to the next or previous page respectively.  ",
-                        "example" : {
-                            "currentPage" : 0,
-                            "pageSize" : 1000,
-                            "totalCount" : 10,
-                            "totalPages" : 1
+                        "currentPageToken" : {
+                            "type" : "string",
+                            "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the current page of data.",
+                            "example" : "48bc6ac1",
+                            "deprecated" : true
+                        },
+                        "prevPageToken" : {
+                            "type" : "string",
+                            "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The string token used to query the previous page of data.",
+                            "example" : "9659857e",
+                            "deprecated" : true
                         }
+                    },
+                    "description" : "**Deprecated in v2.1** Please use `page`. Github issue number #451 \n<br>The pagination object is applicable only when the payload contains a \"data\" key. It describes the pagination of the data contained in the \"data\" array, as a way to identify which subset of data is being returned. \n<br>Tokenized pages are for large data sets which can not be efficiently broken into indexed pages. Use the nextPageToken and prevPageToken to construct an additional query and move to the next or previous page respectively.  ",
+                    "example" : {
+                        "currentPage" : 0,
+                        "pageSize" : 1000,
+                        "totalCount" : 10,
+                        "totalPages" : 1
                     }
-                ]
+                } ]
             }
         },
         "responses" : {
@@ -4364,10 +3848,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ObservationVariableSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4390,10 +3871,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "SeedLotSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4416,10 +3894,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "VariantSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4470,10 +3945,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "StudySingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4496,10 +3968,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "MarkerPositionListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4509,9 +3978,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4533,10 +4000,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "TrialListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4546,9 +4010,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4570,10 +4032,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "MethodSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4596,10 +4055,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "SeedLotListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4609,9 +4065,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4633,10 +4087,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "VariantSetListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4646,9 +4097,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4670,10 +4119,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "SampleSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4696,10 +4142,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "CallSetListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4709,9 +4152,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4733,10 +4174,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "CallSetSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4759,10 +4197,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "VariantSetSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4785,10 +4220,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ReferenceSetSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4811,10 +4243,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ObservationVariableListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4824,9 +4253,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4848,10 +4275,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "CrossListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4861,9 +4285,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4885,10 +4307,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ImageSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4911,10 +4330,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "PlateListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4924,9 +4340,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4948,10 +4362,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "SeasonListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4961,9 +4372,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -4985,10 +4394,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ObservationUnitListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -4998,9 +4404,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5022,10 +4426,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ReferenceListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5035,9 +4436,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5059,10 +4458,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ObservationListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5072,9 +4468,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5096,10 +4490,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "AlleleMatrixListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5109,9 +4500,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5133,10 +4522,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "GenomeMapSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5159,10 +4545,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "PersonListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5172,9 +4555,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5196,10 +4577,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "PlannedCrossListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5209,9 +4587,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5233,10 +4609,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "LocationListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5246,9 +4619,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5281,10 +4652,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "OntologySingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5307,10 +4675,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ProgramListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5320,9 +4685,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5344,10 +4707,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ObservationUnitSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5370,10 +4730,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ScaleListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5383,9 +4740,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5407,10 +4762,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ListListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5420,9 +4772,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5455,10 +4805,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "MethodListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5468,9 +4815,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5492,10 +4837,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "CrossingProjectListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5505,9 +4847,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5529,10 +4869,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "GermplasmAttributeSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5555,10 +4892,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "TraitSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5592,10 +4926,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "GermplasmAttributeListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5605,9 +4936,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5629,10 +4958,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "GermplasmListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5642,9 +4968,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5666,10 +4990,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "CrossingProjectSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5692,10 +5013,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "EventListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5705,9 +5023,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5729,10 +5045,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "TraitListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5742,9 +5055,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5766,10 +5077,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "SampleListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5779,9 +5087,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5803,10 +5109,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ReferenceSetListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5816,9 +5119,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5840,10 +5141,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "TrialSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5866,10 +5164,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "GermplasmSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5892,10 +5187,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "SeasonSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5918,10 +5210,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ReferenceSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5944,10 +5233,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "OntologyListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -5957,9 +5243,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -5992,10 +5276,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "StudyListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6005,9 +5286,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6029,10 +5308,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ScaleSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6055,10 +5331,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "BreedingMethodSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6081,10 +5354,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "CallListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6094,9 +5364,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6118,10 +5386,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "LocationSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6144,10 +5409,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "PersonSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6170,10 +5432,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ImageListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6183,9 +5442,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6207,10 +5464,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "VariantListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6220,9 +5474,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6244,10 +5496,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "PlateSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6270,10 +5519,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "GermplasmAttributeValueListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6283,9 +5529,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6307,10 +5551,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "BreedingMethodListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6320,9 +5561,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6344,10 +5583,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "GermplasmAttributeValueSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6370,10 +5606,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "GenomeMapListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6383,9 +5616,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6407,10 +5638,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "PedigreeNodeListResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6420,9 +5648,7 @@
                                     "$ref" : "#/components/schemas/metadata"
                                 },
                                 "result" : {
-                                    "required" : [
-                                        "data"
-                                    ],
+                                    "required" : [ "data" ],
                                     "type" : "object",
                                     "properties" : {
                                         "data" : {
@@ -6444,10 +5670,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ObservationSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6470,10 +5693,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ListSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {
@@ -6496,10 +5716,7 @@
                     "application/json" : {
                         "schema" : {
                             "title" : "ProgramSingleResponse",
-                            "required" : [
-                                "metadata",
-                                "result"
-                            ],
+                            "required" : [ "metadata", "result" ],
                             "type" : "object",
                             "properties" : {
                                 "@context" : {


### PR DESCRIPTION
Added a section to the OpenAPI options so that we can add supplemental OpenAPI files to get added to the generated spec. Primarily for GET /serverinfo, but useful for other things as development progresses.

Also, `OpenAPIGeneratorTest.generateGermplasmAndStudySeparateByModule` was failing when I ran it, but passed fine when I debugged it. I'm not sure if this is an issue with my machine or some kind of race condition. 